### PR TITLE
ci: skip clang tools for dependabot updates

### DIFF
--- a/.github/workflows/main-review.yaml
+++ b/.github/workflows/main-review.yaml
@@ -85,14 +85,14 @@ jobs:
 
   test-and-coverage:
     needs: [run-clang-tools]
-    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && !contains(github.event.head_commit.message, '[skip test]') }}
     uses: ./.github/workflows/test-and-coverage.yaml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test-build:
     needs: [run-clang-tools]
-    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && !contains(github.event.head_commit.message, '[skip test]') }}
     runs-on: ubuntu-latest
     steps:
       - uses: lukka/get-cmake@latest


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [ ] Have you built the project locally without any warnings and errors?
- [ ] Does all tests (if new tests are added, including the new ones) pass?

If you added new feature, then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #52.

---

<!-- Start the description of the PR here -->
