### PR TITLE
ci: use urllib3 < 2.0 to fix python 3.7 build

### DIFF
--- a/pyproject.toml.in
+++ b/pyproject.toml.in
@@ -68,7 +68,7 @@ NURI_ENABLE_IPO = "@NURI_ENABLE_IPO@"
 [tool.cibuildwheel]
 build = ["cp*-manylinux_x86_64"]
 
-test-requires = ["sphinx"]
+test-requires = ["sphinx", "urllib3<2.0"]
 test-command = [
     "cmake -S {project} -B .",
     "cmake --build . --target nuri_python_docs_doctest -j",


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Does all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #146.

---

<!-- Start the description of the PR here -->
