### PR TITLE
ci: run clang tools directly if run on all files

### DIFF
--- a/.github/workflows/_run-clang-tools.yaml
+++ b/.github/workflows/_run-clang-tools.yaml
@@ -11,6 +11,9 @@ on:
       files-changed-only:
         type: boolean
         default: true
+      version:
+        type: string
+        default: "16"
 
 defaults:
   run:
@@ -37,19 +40,33 @@ jobs:
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -S . -B build -G Ninja
 
+      - name: Run clang tools to all files
+        if: ${{ always() && !inputs.files-changed-only }}
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+
+          VERS=${{ inputs.version }}
+          sudo ./llvm.sh $VERS
+          sudo apt-get install -y clang-tidy-$VERS clang-format-$VERS
+          sudo ln -sf clang-tidy-$VERS /usr/bin/clang-tidy
+          sudo ln -sf clang-format-$VERS /usr/bin/clang-format
+
+          ./scripts/run_clang_tools.sh -c
+
       - uses: cpp-linter/cpp-linter-action@v2
+        if: ${{ always() && inputs.files-changed-only }}
         id: clang-tools
         with:
-          version: "16"
+          version: ${{ inputs.version }}
           extensions: "cpp,hpp,c,h"
           style: file
           tidy-checks: ""
           database: build
           ignore: ".github|build|third-party|test"
-          files-changed-only: ${{ inputs.files-changed-only }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Fail fast
-        if: ${{ steps.clang-tools.outputs.checks-failed > 0 }}
+        if: ${{ always() && steps.clang-tools.outputs.checks-failed > 0 }}
         run: echo "Some files failed the linting checks!" && exit 1

--- a/.github/workflows/main-test.yaml
+++ b/.github/workflows/main-test.yaml
@@ -15,7 +15,7 @@ on:
       - ".github/workflows/_run-clang-tools.yaml"
       - "cmake/**"
       - "include/**"
-      - "scripts/check_coverage.sh"
+      - "scripts/**"
       - "src/**"
       - "test/**"
       - "third-party/**"

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -12,6 +12,7 @@ on:
     paths:
       - ".github/workflows/pr-lint.yaml"
       - ".github/workflows/_run-clang-tools.yaml"
+      - "scripts/run_clang_tools.sh"
       - "**.clang-*"
     types:
       - opened

--- a/scripts/run_clang_tools.sh
+++ b/scripts/run_clang_tools.sh
@@ -16,7 +16,19 @@ if [[ ! -d build ]]; then
 	exit 1
 fi
 
+cf_args=("-i")
+while getopts 'c' opt; do
+	case "$opt" in
+	c) cf_args=(-n --Werror) ;;
+	*) break ;;
+	esac
+done
+
+shift $((OPTIND - 1))
+
 files="$(mktemp)"
+trap 'rm -f "$files"' INT TERM EXIT
+
 if [[ $# -eq 0 ]]; then
 	find include src python/nuri \
 		\( -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' \) -print0 >"$files"
@@ -24,5 +36,5 @@ else
 	printf '%s\0' "$@" >"$files"
 fi
 
-xargs -0 -P0 -n1 clang-format -i <"$files"
-xargs -0 -P0 -n1 clang-tidy -p build --extra-arg-before=-Werror <"$files"
+xargs -0 -P0 -n1 clang-format "${cf_args[@]}" <"$files"
+xargs -0 -P0 -n1 clang-tidy -p build --warnings-as-errors='*' <"$files"


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](htxp://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Does all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #...

---

<!-- Start the description of the PR here -->
