### PR TITLE
feat(python): mark iterables with corresponding types

### DIFF
--- a/cmake/NuriKitUtils.cmake
+++ b/cmake/NuriKitUtils.cmake
@@ -128,7 +128,7 @@ endfunction()
 function(find_or_fetch_pybind11)
   set(BUILD_TESTING OFF)
 
-  find_package(pybind11 2.11.1)
+  find_package(pybind11 2.12.0)
 
   if(pybind11_FOUND)
     message(STATUS "Found pybind11 ${pybind11_VERSION}")
@@ -139,7 +139,7 @@ function(find_or_fetch_pybind11)
     Fetchcontent_Declare(
       pybind11
       GIT_REPOSITORY https://github.com/pybind/pybind11.git
-      GIT_TAG v2.11.1
+      GIT_TAG v2.12.0
     )
     nuri_make_available_deponly(pybind11)
   endif()

--- a/python/include/nuri/python/config.h
+++ b/python/include/nuri/python/config.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <pybind11/pybind11.h>
+#include <pybind11/typing.h>
 
 #include "nuri/core/element.h"
 
@@ -23,6 +24,9 @@ namespace nuri {
 namespace python_internal {
 // NOLINTNEXTLINE(misc-unused-alias-decls)
 namespace py = pybind11;
+// NOLINTNEXTLINE(misc-unused-alias-decls)
+namespace pyt = pybind11::typing;
+
 using rvp = py::return_value_policy;
 
 using PropertyMap = std::vector<std::pair<std::string, std::string>>;

--- a/python/include/nuri/python/core/core_module.h
+++ b/python/include/nuri/python/core/core_module.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <Eigen/Dense>
@@ -1407,9 +1408,12 @@ Copy the underlying :class:`BondData` object.
   return cls;
 }
 
+using AtomsArg = pyt::Iterable<std::variant<PyAtom, int>>;
+using BondsArg = pyt::Iterable<std::variant<PyBond, int>>;
+
 extern Substructure create_substruct(Molecule &mol,
-                                     const std::optional<py::iterable> &atoms,
-                                     const std::optional<py::iterable> &bonds,
+                                     const std::optional<AtomsArg> &atoms,
+                                     const std::optional<BondsArg> &bonds,
                                      SubstructCategory cat);
 
 /* Called from bind_molecule, don't call directly */

--- a/python/src/nuri/core/containers.cpp
+++ b/python/src/nuri/core/containers.cpp
@@ -14,6 +14,7 @@
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
+#include <pybind11/typing.h>
 
 #include <absl/algorithm/container.h>
 
@@ -315,11 +316,13 @@ py::class_<T> &add_map_interface(py::class_<T> &cls) {
     for (auto item: kwargs)
       map_setitem_py(map, item.first, item.second);
   });
-  cls.def("update", [](T &self, const py::iterable &other) {
-    PropertyMap &map = prolog(self);
-    for (auto item: other)
-      map_setitem_unpack(map, item);
-  });
+  cls.def("update",
+          [](T &self,
+             const pyt::Iterable<pyt::Tuple<py::str, py::str>> &other) {
+            PropertyMap &map = prolog(self);
+            for (auto item: other)
+              map_setitem_unpack(map, item);
+          });
   cls.def("setdefault", [](T &self, std::string_view key, py::str def) {
     PropertyMap &map = prolog(self);
 

--- a/python/src/nuri/core/molecule.cpp
+++ b/python/src/nuri/core/molecule.cpp
@@ -19,6 +19,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>
+#include <pybind11/typing.h>
 
 #include <absl/log/absl_log.h>
 #include <absl/strings/str_cat.h>
@@ -927,8 +928,8 @@ Add all atoms and bonds from a substructure to the molecule.
 )doc")
       .def(
           "sub",
-          [](PyMol &self, const std::optional<py::iterable> &as,
-             const std::optional<py::iterable> &bs, SubstructCategory cat) {
+          [](PyMol &self, const std::optional<AtomsArg> &as,
+             const std::optional<BondsArg> &bs, SubstructCategory cat) {
             return PySubstruct::from_mol(self,
                                          create_substruct(*self, as, bs, cat));
           },

--- a/python/src/nuri/core/substructure.cpp
+++ b/python/src/nuri/core/substructure.cpp
@@ -548,7 +548,7 @@ to the conformers to update the coordinates.
 )doc");
   sub.def(
       "add_atoms",
-      [](P &self, const py::iterable &atoms, bool add_bonds) {
+      [](P &self, const AtomsArg &atoms, bool add_bonds) {
         Substructure &substruct = *self;
         Molecule &parent = *self.parent();
 
@@ -577,7 +577,7 @@ Add atoms to the substructure.
 )doc");
   sub.def(
       "add_bonds",
-      [](P &self, const py::iterable &bonds) {
+      [](P &self, const BondsArg &bonds) {
         Substructure &substruct = *self;
         Molecule &parent = *self.parent();
 
@@ -865,8 +865,8 @@ int check_sub(const Molecule &mol, int idx) {
 }
 
 void insert_substruct(ProxySubstructContainer &cont, int idx,
-                      const std::optional<py::iterable> &atoms,
-                      const std::optional<py::iterable> &bonds,
+                      const std::optional<AtomsArg> &atoms,
+                      const std::optional<BondsArg> &bonds,
                       SubstructCategory cat) {
   Molecule &mol = *cont.mol();
   auto &substructs = mol.substructures();
@@ -920,8 +920,8 @@ SubstructCategory get_or_throw_cat(SubstructCategory cat) {
 }
 
 Substructure create_substruct(Molecule &mol,
-                              const std::optional<py::iterable> &atoms,
-                              const std::optional<py::iterable> &bonds,
+                              const std::optional<AtomsArg> &atoms,
+                              const std::optional<BondsArg> &bonds,
                               SubstructCategory cat) {
   cat = get_or_throw_cat(cat);
 
@@ -1110,8 +1110,8 @@ Remove a substructure from the collection and return it.
       .def(
           "add",
           [](ProxySubstructContainer &self,
-             const std::optional<py::iterable> &atoms,
-             const std::optional<py::iterable> &bonds, SubstructCategory cat) {
+             const std::optional<AtomsArg> &atoms,
+             const std::optional<BondsArg> &bonds, SubstructCategory cat) {
             int idx = self.size();
             insert_substruct(self, idx, atoms, bonds, cat);
             return self.get(idx);
@@ -1147,8 +1147,8 @@ This has three mode of operations:
       .def(
           "add",
           [](ProxySubstructContainer &self, int idx,
-             const std::optional<py::iterable> &atoms,
-             const std::optional<py::iterable> &bonds, SubstructCategory cat) {
+             const std::optional<AtomsArg> &atoms,
+             const std::optional<BondsArg> &bonds, SubstructCategory cat) {
             idx = wrap_insert_index(self.size(), idx);
             insert_substruct(self, idx, atoms, bonds, cat);
             self.mol().tock();

--- a/test/fmt/sdf_test.cpp
+++ b/test/fmt/sdf_test.cpp
@@ -13,7 +13,6 @@
 
 #include "nuri/eigen_config.h"
 #include "fmt_test_common.h"
-#include "gtest/gtest.h"
 #include "nuri/core/element.h"
 #include "nuri/core/molecule.h"
 #include "nuri/utils.h"


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Does all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #263.

---

<!-- Start the description of the PR here -->
