### PR TITLE
fix(fmt/mol2): escape whitespaces when writing

### DIFF
--- a/include/nuri/fmt/base.h
+++ b/include/nuri/fmt/base.h
@@ -390,6 +390,26 @@ private:
   char delim_;
   internal::DumbBuffer<char> buf_;
 };
+
+namespace internal {
+  /**
+   * @brief Replace non-ascii and non-printable characters with '?' and replace
+   *        all whitespace characters with '_'.
+   *
+   * @param str The string to sanitize.
+   * @return The sanitized string.
+   */
+  extern std::string ascii_safe(std::string_view str);
+
+  /**
+   * @brief Replace non-ascii and non-printable characters with '?' and replace
+   *        all newline characters with ' '.
+   *
+   * @param str The string to sanitize.
+   * @return The sanitized string.
+   */
+  extern std::string ascii_newline_safe(std::string_view str);
+}  // namespace internal
 }  // namespace nuri
 
 #endif /* NURI_FMT_BASE_H_ */

--- a/src/fmt/base.cpp
+++ b/src/fmt/base.cpp
@@ -22,6 +22,7 @@
 #include <absl/log/absl_check.h>
 #include <absl/log/absl_log.h>
 #include <absl/strings/ascii.h>
+#include <absl/strings/charset.h>
 
 #include "fmt_internal.h"
 
@@ -42,6 +43,23 @@ std::string ascii_safe(std::string_view str) {
     if (absl::ascii_isspace(c)) {
       c = '_';
     } else if (ABSL_PREDICT_FALSE(!absl::ascii_isprint(c))) {
+      c = '?';
+    }
+  }
+
+  return ret;
+}
+
+constexpr static const absl::CharSet kNewlines("\f\n\r");
+
+std::string ascii_newline_safe(std::string_view str) {
+  std::string ret(str);
+
+  for (char &c: ret) {
+    if (kNewlines.contains(c)) {
+      c = ' ';
+    } else if (!absl::ascii_isspace(c)
+               && ABSL_PREDICT_FALSE(!absl::ascii_isprint(c))) {
       c = '?';
     }
   }

--- a/src/fmt/base.cpp
+++ b/src/fmt/base.cpp
@@ -24,8 +24,6 @@
 #include <absl/strings/ascii.h>
 #include <absl/strings/charset.h>
 
-#include "fmt_internal.h"
-
 namespace nuri {
 namespace {
 absl::flat_hash_map<std::string, const MoleculeReaderFactory *> &

--- a/src/fmt/fmt_internal.h
+++ b/src/fmt/fmt_internal.h
@@ -57,6 +57,15 @@ namespace internal {
  * @return The sanitized string.
  */
 extern std::string ascii_safe(std::string_view str);
+
+/**
+ * @brief Replace non-ascii and non-printable characters with '?' and replace
+ *        all newline characters with ' '.
+ *
+ * @param str The string to sanitize.
+ * @return The sanitized string.
+ */
+extern std::string ascii_newline_safe(std::string_view str);
 }  // namespace internal
 }  // namespace nuri
 #endif /* NURI_FMT_FMT_INTERNAL_H_ */

--- a/src/fmt/fmt_internal.h
+++ b/src/fmt/fmt_internal.h
@@ -7,7 +7,6 @@
 #define NURI_FMT_FMT_INTERNAL_H_
 
 #include <string>
-#include <string_view>
 
 #include <boost/spirit/home/x3.hpp>
 
@@ -47,25 +46,5 @@ constexpr auto uint_trailing_blanks = TrailingBlanksRule<unsigned int>() =
 }  // namespace parser
 // NOLINTEND(readability-identifier-naming,*-unused-const-variable)
 }  // namespace
-
-namespace internal {
-/**
- * @brief Replace non-ascii and non-printable characters with '?' and replace
- *        all whitespace characters with '_'.
- *
- * @param str The string to sanitize.
- * @return The sanitized string.
- */
-extern std::string ascii_safe(std::string_view str);
-
-/**
- * @brief Replace non-ascii and non-printable characters with '?' and replace
- *        all newline characters with ' '.
- *
- * @param str The string to sanitize.
- * @return The sanitized string.
- */
-extern std::string ascii_newline_safe(std::string_view str);
-}  // namespace internal
 }  // namespace nuri
 #endif /* NURI_FMT_FMT_INTERNAL_H_ */

--- a/test/fmt/base_test.cpp
+++ b/test/fmt/base_test.cpp
@@ -6,9 +6,12 @@
 #include "nuri/fmt/base.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <gtest/gtest.h>
+
+#include "../src/fmt/fmt_internal.h"
 
 namespace nuri {
 namespace {
@@ -84,6 +87,20 @@ TEST(ReversedStreamTest, ReadBackwardsMixed) {
   for (size_t i = 0; i < forward.size(); ++i) {
     EXPECT_EQ(forward[i], backward[backward.size() - i - 1]);
   }
+}
+
+TEST(EscapeTest, EscapeAll) {
+  // unicode thumbs up emoji (utf8)
+  std::string_view unsafe = "  a\nb\tc\rd e \xf0\x9f\x91\x8d  ";
+  std::string escaped = internal::ascii_safe(unsafe);
+  EXPECT_EQ(escaped, "__a_b_c_d_e_????__");
+}
+
+TEST(EscapeTest, EscapeNewlines) {
+  // unicode thumbs up emoji (utf8)
+  std::string_view unsafe = "  a\nb\tc\rd e \xf0\x9f\x91\x8d  ";
+  std::string escaped = internal::ascii_newline_safe(unsafe);
+  EXPECT_EQ(escaped, "  a b\tc d e ????  ");
 }
 }  // namespace
 }  // namespace nuri

--- a/test/fmt/base_test.cpp
+++ b/test/fmt/base_test.cpp
@@ -11,8 +11,6 @@
 
 #include <gtest/gtest.h>
 
-#include "../src/fmt/fmt_internal.h"
-
 namespace nuri {
 namespace {
 TEST(ReversedStreamTest, HandleEmptyFile) {

--- a/test/fmt/base_test.cpp
+++ b/test/fmt/base_test.cpp
@@ -5,6 +5,8 @@
 
 #include "nuri/fmt/base.h"
 
+#include <cstddef>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Does all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [x] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #279.

---

<!-- Start the description of the PR here -->
