### PR TITLE
fix(python/core): fix bug on Molecule::clear* call with active mutator 

### DIFF
--- a/python/include/nuri/python/core/core_module.h
+++ b/python/include/nuri/python/core/core_module.h
@@ -76,6 +76,32 @@ public:
 
   std::uint64_t sub_version() const { return substruct_version_; }
 
+  void clear_atoms() {
+    if (has_mutator_)
+      throw std::runtime_error(
+          "cannot clear atoms/bonds of molecule with active mutator");
+
+    (**this).clear_atoms();
+    tick();
+  }
+
+  void clear_bonds() {
+    if (has_mutator_)
+      throw std::runtime_error(
+          "cannot clear bonds of molecule with active mutator");
+
+    (**this).clear_bonds();
+    tick();
+  }
+
+  void clear() {
+    if (has_mutator_)
+      throw std::runtime_error("cannot clear molecule with active mutator");
+
+    (**this).clear();
+    tick();
+  }
+
   auto mutator() {
     if (has_mutator_)
       throw std::runtime_error("molecule already has a mutator");
@@ -119,6 +145,21 @@ public:
   PyAtom add_atom(AtomData &&data);
 
   PyBond add_bond(int src, int dst, BondData &&data);
+
+  void clear_atoms() {
+    mut().clear_atoms();
+    mol_->tick();
+  }
+
+  void clear_bonds() {
+    mut().clear_bonds();
+    mol_->tick();
+  }
+
+  void clear() {
+    mut().clear();
+    mol_->tick();
+  }
 
   MoleculeMutator &mut() {
     if (!mut_)

--- a/python/src/nuri/core/molecule.cpp
+++ b/python/src/nuri/core/molecule.cpp
@@ -858,41 +858,39 @@ implicit hydrogens).
 .. note::
   Invalidates all atom and bond objects.
 )doc")
-      .def(
-          "clear_atoms",
-          [](PyMol &self) {
-            self->clear_atoms();
-            self.tick();
-          },
-          R"doc(
+      .def("clear_atoms", &PyMol::clear_atoms,
+           R"doc(
 Clear all atoms and bonds of the molecule. Other metadata are left unmodified.
 
 .. note::
   Invalidates all atom and bond objects.
+.. warning::
+  Molecules with active mutator context cannot clear atoms.
+.. seealso::
+  :meth:`Mutator.clear_atoms`
 )doc")
-      .def(
-          "clear_bonds",
-          [](PyMol &self) {
-            self->clear_bonds();
-            self.tick();
-          },
-          R"doc(
+      .def("clear_bonds", &PyMol::clear_bonds,
+           R"doc(
 Clear all bonds of the molecule. Atoms and other metadata are left unmodified.
 
 .. note::
   Invalidates all atom and bond objects.
+.. warning::
+  Molecules with active mutator context cannot clear bonds.
+.. seealso::
+  :meth:`Mutator.clear_bonds`
 )doc")
-      .def(
-          "clear",
-          [](PyMol &self) {
-            self->clear();
-            self.tick();
-          },
-          R"doc(
+      .def("clear", &PyMol::clear,
+           R"doc(
 Effectively resets the molecule to an empty state.
 
 .. note::
   Invalidates all atom and bond objects.
+
+.. warning::
+  Molecules with active mutator context cannot be cleared.
+.. seealso::
+  :meth:`Mutator.clear`
 )doc")
       .def(
           "add_from",
@@ -1178,6 +1176,24 @@ Mark a bond to be erased from the molecule. The bond is not erased until the
 context manager is exited.
 
 :param bond: The bond to erase.
+)doc")
+      .def("clear_atoms", &PyMutator::clear_atoms, R"doc(
+Clear all atoms and bonds of the molecule. Other metadata are left unmodified.
+
+.. note::
+  Invalidates all atom and bond objects.
+)doc")
+      .def("clear_bonds", &PyMutator::clear_bonds, R"doc(
+Clear all bonds of the molecule. Atoms and other metadata are left unmodified.
+
+.. note::
+  Invalidates all atom and bond objects.
+)doc")
+      .def("clear", &PyMutator::clear, R"doc(
+Effectively resets the molecule to an empty state.
+
+.. note::
+  Invalidates all atom and bond objects.
 )doc")
       .def("__enter__", &PyMutator::initialize)
       .def("__exit__",

--- a/python/test/core/molecule_test.py
+++ b/python/test/core/molecule_test.py
@@ -44,6 +44,15 @@ def test_mutator_errors():
         mut1.add_atom(6)
 
         with pytest.raises(RuntimeError):
+            mol.clear()
+
+        with pytest.raises(RuntimeError):
+            mol.clear_atoms()
+
+        with pytest.raises(RuntimeError):
+            mol.clear_bonds()
+
+        with pytest.raises(RuntimeError):
             with mol.mutator():
                 pass
 
@@ -322,6 +331,39 @@ def test_clear_atoms(mol: Molecule):
     assert not mol
     assert not mol.bonds()
     assert mol.name == "test"
+
+
+def test_clear_bonds_mutator(mol: Molecule):
+    mol.name = "test"
+
+    with mol.mutator() as mut:
+        mut.clear_bonds()
+
+    assert not mol.bonds()
+    assert mol.num_atoms() == 11
+    assert mol.name == "test"
+
+
+def test_clear_atoms_mutator(mol: Molecule):
+    mol.name = "test"
+
+    with mol.mutator() as mut:
+        mut.clear_atoms()
+
+    assert not mol
+    assert not mol.bonds()
+    assert mol.name == "test"
+
+
+def test_clear_mutator(mol: Molecule):
+    mol.name = "test"
+
+    with mol.mutator() as mut:
+        mut.clear()
+
+    assert not mol
+    assert not mol.bonds()
+    assert not mol.name
 
 
 def test_add_other(mol: Molecule):


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Does all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [x] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Fixes #289.

---

<!-- Start the description of the PR here -->
