### PR TITLE
fix(fmt/mol2): silence warning message when trailing blanks found

### DIFF
--- a/src/fmt/mol2.cpp
+++ b/src/fmt/mol2.cpp
@@ -188,7 +188,8 @@ constexpr auto atom_line = *x3::omit[x3::blank]         //
                            >> -(+x3::omit[x3::blank]              //
                                 >> uint_trailing_blanks           //
                                 >> -(nonblank_trailing_blanks     //
-                                     >> -x3::double_));
+                                     >> -x3::double_))
+                           >> *x3::omit[x3::blank];
 using AtomLine = std::tuple<
     unsigned int, std::string, absl::InlinedVector<double, 3>, std::string,
     boost::optional<std::string>,


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Does all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Fixes #295.

---

<!-- Start the description of the PR here -->
