### PR TITLE
fix(fmt/smi): use correct bond order sum for smiles string

### DIFF
--- a/src/fmt/smiles.cpp
+++ b/src/fmt/smiles.cpp
@@ -446,7 +446,7 @@ void update_implicit_hydrogens(Molecule::MutableAtom atom) {
   // Required for correct bond order calculation
   atom.data().set_implicit_hydrogens(0);
 
-  int sum_bo = internal::sum_bond_order(atom, false), normal_valence;
+  int sum_bo = sum_bond_order(atom), normal_valence;
 
   switch (atom.data().atomic_number()) {
   case 0:

--- a/test/core/molecule_test.cpp
+++ b/test/core/molecule_test.cpp
@@ -1120,6 +1120,13 @@ TEST(SanitizeTest, Samples) {
   for (auto atom: mol)
     EXPECT_EQ(atom.data().is_aromatic(), atom.id() != 0) << atom.id();
 
+  for (int i: { 1, 2, 5, 6, 7 }) {
+    auto atom = mol.atom(i);
+    EXPECT_EQ(atom.data().hybridization(), kSP2) << i;
+    EXPECT_EQ(atom.data().implicit_hydrogens(), 0) << i;
+    EXPECT_EQ(atom.data().formal_charge(), 0) << i;
+  }
+
   mol.clear();
 
   {

--- a/test/fmt/smiles_test.cpp
+++ b/test/fmt/smiles_test.cpp
@@ -694,6 +694,11 @@ TEST_F(SmilesTest, DUDEExamplesTest) {
   std::string smi;
 
   NURI_FMT_TEST_NEXT_MOL("C02302104", 26, 29);
+
+  // GH-298
+  EXPECT_EQ(mol()[13].data().implicit_hydrogens(), 0);
+  EXPECT_EQ(mol()[13].data().formal_charge(), 0);
+
   write_smiles(smi, mol());
 
   set_test_string(smi);


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Does all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [x] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #298.

---

<!-- Start the description of the PR here -->
