### PR TITLE
fix(fmt/pdb): strip occupancy and tempfactor

### DIFF
--- a/src/fmt/pdb.cpp
+++ b/src/fmt/pdb.cpp
@@ -1676,9 +1676,9 @@ public:
     for (const AtomicLine &l: lines_) {
       data.add_prop(as_key("serial", l.altloc()), absl::StrCat(l.serial()));
       data.add_prop(as_key("occupancy", l.altloc()),
-                    safe_slice(l.line(), 54, 60));
+                    safe_slice_strip(l.line(), 54, 60));
       data.add_prop(as_key("tempfactor", l.altloc()),
-                    safe_slice(l.line(), 60, 66));
+                    safe_slice_strip(l.line(), 60, 66));
     }
     data.props().insert(data.props().end(),
                         std::make_move_iterator(extra_.begin()),


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Does all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #362.

---

<!-- Start the description of the PR here -->
