### PR TITLE
build: set C++ standard with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,9 @@ elseif(NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     "Please use clang or gcc as a compiler.")
 endif()
 
-# for math optimization flags
-string(APPEND CMAKE_CXX_FLAGS " -std=c++17")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(NURI_GLOBAL_OPTFLAGS " -${NURI_OPTIMIZATION_LEVEL}")

--- a/cmake/NuriKitUtils.cmake
+++ b/cmake/NuriKitUtils.cmake
@@ -86,12 +86,6 @@ function(nuri_get_version)
   set(NURI_REF "${NURI_REF}" PARENT_SCOPE)
 endfunction()
 
-macro(nuri_set_cxx_standard)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endmacro()
-
 function(nuri_make_available_deponly target)
   include(FetchContent)
 
@@ -117,8 +111,6 @@ function(target_system_include_directories target)
 endfunction()
 
 function(find_or_fetch_eigen)
-  nuri_set_cxx_standard()
-
   set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
   set(BUILD_TESTING OFF)
   set(EIGEN_BUILD_DOC OFF)
@@ -141,7 +133,6 @@ function(find_or_fetch_eigen)
 endfunction()
 
 function(find_or_fetch_spectra)
-  nuri_set_cxx_standard()
   set(BUILD_TESTING OFF)
 
   find_package(Spectra 1.0 QUIET)
@@ -162,7 +153,6 @@ function(find_or_fetch_spectra)
 endfunction()
 
 function(find_or_fetch_pybind11)
-  nuri_set_cxx_standard()
   set(BUILD_TESTING OFF)
 
   # FindPythonInterp/FindPythonLibs deprecated since cmake 3.12
@@ -188,7 +178,6 @@ function(find_or_fetch_pybind11)
 endfunction()
 
 function(handle_boost_dependency target)
-  nuri_set_cxx_standard()
   set(BUILD_TESTING OFF)
 
   # FindBoost deprecated since cmake 3.30

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -3,9 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-include(NuriKitUtils)
-nuri_set_cxx_standard()
-
 # Don't fail build on warnings from third-party code.
 add_compile_options(-Wno-error)
 


### PR DESCRIPTION
It turns out that where the standard flag appears in the command line does not affect compiler code generation.

Partial revert of commit cfc81ea0.

## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Does all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #...

---

<!-- Start the description of the PR here -->
