### PR TITLE
feat(python/tools/tm): assume full alignment when no user-alignment provided

### DIFF
--- a/python/include/nuri/python/utils.h
+++ b/python/include/nuri/python/utils.h
@@ -423,6 +423,9 @@ NpArrayLike<ML> empty_like(const ML &mat) {
 template <Eigen::Index Rows = Eigen::Dynamic,
           Eigen::Index Cols = Eigen::Dynamic, class DT = double>
 NpArrayWrapper<Rows, Cols, DT> py_array_cast(py::handle h) {
+  if (h.is_none())
+    throw py::type_error("expected array-like object, got None");
+
   PyObject *result = NpArrayWrapper<Rows, Cols, DT>::raw_array_t(h.ptr());
   if (result == nullptr) {
     py::error_already_set current_exc;

--- a/python/test/core/numpy_cvt_test.py
+++ b/python/test/core/numpy_cvt_test.py
@@ -114,3 +114,6 @@ def test_cast_convert_failed():
 
     with pytest.raises(ValueError, match="cannot convert"):
         cast_test_helper(obj, "dynamic")
+
+    with pytest.raises(TypeError, match="got None"):
+        cast_test_helper(None, "dynamic")

--- a/python/test/tools/tm_test.py
+++ b/python/test/tools/tm_test.py
@@ -150,6 +150,13 @@ def test_tm_score(
     assert score == pytest.approx(score_ref, rel=1e-5)
 
 
+def test_tm_score_self(query: np.ndarray):
+    xform, score = tmtools.tm_score(query, query)
+
+    assert xform == pytest.approx(np.eye(4), rel=1e-5)
+    assert score == pytest.approx(1.0, rel=1e-5)
+
+
 def test_tm_align_full(
     query: np.ndarray,
     templ: np.ndarray,
@@ -196,3 +203,6 @@ def test_tm_errors():
 
     with pytest.raises(ValueError, match="out-of-range"):
         tmtools.tm_score(np.zeros((11, 3)), np.zeros((10, 3)), [(0, 10)])
+
+    with pytest.raises(ValueError, match="must have the same length"):
+        tmtools.tm_score(np.zeros((11, 3)), np.zeros((10, 3)))


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Does all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [x] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

---

<!-- Start the description of the PR here -->
