### PR TITLE
build: cleanup stale coverage data before linking

### DIFF
--- a/cmake/NuriKitClearCoverage.cmake
+++ b/cmake/NuriKitClearCoverage.cmake
@@ -1,0 +1,21 @@
+#
+# Project NuriKit - Copyright 2024 SNU Compbio Lab.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+if(NOT CMAKE_SCRIPT_MODE_FILE)
+  message(WARNING "This file must be executed with CMake in script mode, not included with include() or add_subdirectory().")
+  return()
+endif()
+
+if(NOT NURI_COVERAGE_DATA_DIR)
+  message(FATAL_ERROR "No parent directory provided.")
+endif()
+
+file(GLOB_RECURSE nuri_gcda LIST_DIRECTORIES OFF "${NURI_COVERAGE_DATA_DIR}/*.gcda")
+
+if(nuri_gcda)
+  list(LENGTH nuri_gcda nuri_gcda_count)
+  message(NOTICE "Removing ${nuri_gcda_count} gcda files in ${NURI_COVERAGE_DATA_DIR}")
+  file(REMOVE ${nuri_gcda})
+endif()

--- a/cmake/NuriKitClearStubs.cmake
+++ b/cmake/NuriKitClearStubs.cmake
@@ -8,14 +8,14 @@ if(NOT CMAKE_SCRIPT_MODE_FILE)
   return()
 endif()
 
-if(NOT CMAKE_ARGV1)
+if(NOT NURI_STUBS_DIR)
   message(FATAL_ERROR "No parent directory provided.")
 endif()
 
-file(GLOB_RECURSE nuri_stubs LIST_DIRECTORIES OFF "${CMAKE_ARGV1}/*.pyi")
+file(GLOB_RECURSE nuri_stubs LIST_DIRECTORIES OFF "${NURI_STUBS_DIR}/*.pyi")
 
 if(nuri_stubs)
-  list(JOIN nuri_stubs ", \n" nuri_stubs_msg)
-  message(NOTICE "Removing the following stubs:\n${nuri_stubs_msg}")
+  list(JOIN nuri_stubs "\n\t" nuri_stubs_msg)
+  message(NOTICE "Removing the following stubs:\n\t${nuri_stubs_msg}")
   file(REMOVE ${nuri_stubs})
 endif()

--- a/cmake/NuriKitPythonUtils.cmake
+++ b/cmake/NuriKitPythonUtils.cmake
@@ -7,9 +7,10 @@ add_custom_command(
   TARGET nuri_python
   POST_BUILD
   COMMAND "${CMAKE_COMMAND}"
+  "-DNURI_STUBS_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
   -P "${PROJECT_SOURCE_DIR}/cmake/NuriKitClearStubs.cmake"
-  "${CMAKE_CURRENT_SOURCE_DIR}"
-  VERBATIM)
+  VERBATIM
+)
 
 find_program(PYBIND11_STUBGEN pybind11-stubgen)
 mark_as_advanced(PYBIND11_STUBGEN)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,17 @@ target_link_libraries(nuri_lib
 target_system_include_directories(nuri_lib Eigen3::Eigen Spectra::Spectra)
 handle_boost_dependency(nuri_lib)
 
+if(NURI_TEST_COVERAGE)
+  add_custom_command(
+    TARGET nuri_lib
+    PRE_LINK
+    COMMAND "${CMAKE_COMMAND}"
+    "-DNURI_COVERAGE_DATA_DIR=${CMAKE_CURRENT_BINARY_DIR}"
+    -P "${PROJECT_SOURCE_DIR}/cmake/NuriKitClearCoverage.cmake"
+    VERBATIM
+  )
+endif()
+
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   list(APPEND NURI_LIBRARY_FLAGS
     -fno-math-errno


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Does all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #...

---

<!-- Start the description of the PR here -->
