### PR TITLE
build: cleanup more stale coverage data

### DIFF
--- a/cmake/NuriKitClearCoverage.cmake
+++ b/cmake/NuriKitClearCoverage.cmake
@@ -19,3 +19,14 @@ if(nuri_gcda)
   message(NOTICE "Removing ${nuri_gcda_count} gcda files in ${NURI_COVERAGE_DATA_DIR}")
   file(REMOVE ${nuri_gcda})
 endif()
+
+file(GLOB_RECURSE nuri_gcno LIST_DIRECTORIES OFF "${NURI_COVERAGE_DATA_DIR}/*.gcno")
+
+foreach(gcno IN LISTS nuri_gcno)
+  string(REGEX REPLACE "\\.gcno$" ".o" object "${gcno}")
+
+  if(NOT EXISTS "${object}")
+    message(STATUS "Removing stale gcno file: ${gcno}")
+    file(REMOVE "${gcno}")
+  endif()
+endforeach()

--- a/cmake/NuriKitPythonUtils.cmake
+++ b/cmake/NuriKitPythonUtils.cmake
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+include(NuriKitUtils)
+
 add_custom_command(
   TARGET nuri_python
   POST_BUILD
@@ -11,6 +13,7 @@ add_custom_command(
   -P "${PROJECT_SOURCE_DIR}/cmake/NuriKitClearStubs.cmake"
   VERBATIM
 )
+clear_coverage_data(nuri_python)
 
 find_program(PYBIND11_STUBGEN pybind11-stubgen)
 mark_as_advanced(PYBIND11_STUBGEN)

--- a/cmake/NuriKitTest.cmake
+++ b/cmake/NuriKitTest.cmake
@@ -5,6 +5,7 @@
 
 if(NOT TARGET nuri_all_test)
   add_custom_target(nuri_all_test)
+  clear_coverage_data(nuri_all_test)
 
   if(BUILD_TESTING)
     set_target_properties(nuri_all_test PROPERTIES EXCLUDE_FROM_ALL OFF)

--- a/cmake/NuriKitUtils.cmake
+++ b/cmake/NuriKitUtils.cmake
@@ -243,3 +243,18 @@ function(set_sanitizer_envs)
     "LD_PRELOAD=${asan_lib_path} ${ubsan_lib_path} $ENV{LD_PRELOAD}"
     PARENT_SCOPE)
 endfunction()
+
+function(clear_coverage_data target)
+  if(NOT NURI_TEST_COVERAGE)
+    return()
+  endif()
+
+  add_custom_command(
+    TARGET "${target}"
+    POST_BUILD
+    COMMAND "${CMAKE_COMMAND}"
+    "-DNURI_COVERAGE_DATA_DIR=${CMAKE_CURRENT_BINARY_DIR}"
+    -P "${PROJECT_SOURCE_DIR}/cmake/NuriKitClearCoverage.cmake"
+    VERBATIM
+  )
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,17 +33,7 @@ target_link_libraries(nuri_lib
 )
 target_system_include_directories(nuri_lib Eigen3::Eigen Spectra::Spectra)
 handle_boost_dependency(nuri_lib)
-
-if(NURI_TEST_COVERAGE)
-  add_custom_command(
-    TARGET nuri_lib
-    PRE_LINK
-    COMMAND "${CMAKE_COMMAND}"
-    "-DNURI_COVERAGE_DATA_DIR=${CMAKE_CURRENT_BINARY_DIR}"
-    -P "${PROJECT_SOURCE_DIR}/cmake/NuriKitClearCoverage.cmake"
-    VERBATIM
-  )
-endif()
+clear_coverage_data(nuri_lib)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   list(APPEND NURI_LIBRARY_FLAGS


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [ ] Have you built the project locally without any warnings and errors?
- [ ] Does all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

---

<!-- Start the description of the PR here -->
