### PR TITLE
build: switch to abseil lts version to use prebuilt abseil binaries if available

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -51,14 +51,14 @@ ContinuationIndentWidth: 4
 Cpp11BracedListStyle: false
 DerivePointerAlignment: false
 IncludeCategories:
-  - Regex: "^<(absl|gtest|gmock)/.*"
+  - Regex: "^<(gtest|gmock)/.*"
     Priority: 3
     SortPriority: 4
     CaseSensitive: false
   - Regex: "^<.*/.*"
     Priority: 2
     SortPriority: 3
-    CaseSensitive: false
+    CaseSensitive: true
   - Regex: '^<.*\..*>'
     Priority: 2
     SortPriority: 2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "third-party/googletest"]
 	path = third-party/googletest
 	url = https://github.com/google/googletest
-[submodule "third-party/abseil-cpp"]
-	path = third-party/abseil-cpp
-	url = https://github.com/abseil/abseil-cpp

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,7 +20,7 @@ build:
   jobs:
     post_checkout:
       - (git show -s --format='%an' | grep -vq '\[bot\]$') || exit 183
-    pre_create_environment:
+    pre_install:
       - |
         cmake -S . -B pre-install -G Ninja \
           -DCMAKE_BUILD_TYPE=Release \
@@ -40,6 +40,13 @@ build:
 
 conda:
   environment: docs/environment.yaml
+
+python:
+  install:
+    - method: pip
+      path: "."
+      extra_requirements:
+        - docs
 
 sphinx:
   configuration: "python/docs/conf.py"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,7 +20,7 @@ build:
   jobs:
     post_checkout:
       - (git show -s --format='%an' | grep -vq '\[bot\]$') || exit 183
-    pre_install:
+    pre_create_environment:
       - |
         cmake -S . -B pre-install -G Ninja \
           -DCMAKE_BUILD_TYPE=Release \

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,12 +11,10 @@ submodules:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "mambaforge-23.11"
   apt_packages:
     - build-essential
-    - cmake
     - ninja-build
-    - libeigen3-dev
     - doxygen
     - graphviz
   jobs:
@@ -40,12 +38,8 @@ build:
           -DNURI_OPTIMIZATION_LEVEL=O0
       - cmake --build build --target nuri_docs
 
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+conda:
+  environment: docs/environment.yaml
 
 sphinx:
   configuration: "python/docs/conf.py"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ if(CMAKE_BUILD_TYPE MATCHES "Release|MinSizeRel")
 endif()
 
 add_subdirectory(third-party EXCLUDE_FROM_ALL)
+find_or_fetch_abseil()
 
 add_compile_options(
   -pedantic

--- a/cmake/NuriKitUtils.cmake
+++ b/cmake/NuriKitUtils.cmake
@@ -177,6 +177,29 @@ function(find_or_fetch_pybind11)
   endif()
 endfunction()
 
+function(find_or_fetch_abseil)
+  set(BUILD_TESTING OFF)
+  set(ABSL_BUILD_TESTING OFF)
+  set(ABSL_PROPAGATE_CXX_STD ON)
+  set(ABSL_USE_SYSTEM_INCLUDES ON)
+
+  find_package(absl QUIET)
+
+  # 20240116 required for VLOG()
+  if(absl_FOUND AND absl_VERSION VERSION_GREATER_EQUAL 20240116)
+    message(STATUS "Found abseil ${absl_VERSION}")
+  else()
+    include(FetchContent)
+    message(NOTICE "Could not find compatible abseil. Fetching from github.")
+
+    Fetchcontent_Declare(
+      absl
+      URL https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz
+    )
+    nuri_make_available_deponly(absl)
+  endif()
+endfunction()
+
 function(handle_boost_dependency target)
   set(BUILD_TESTING OFF)
 

--- a/cmake/NuriKitUtils.cmake
+++ b/cmake/NuriKitUtils.cmake
@@ -179,11 +179,19 @@ endfunction()
 
 function(find_or_fetch_abseil)
   set(BUILD_TESTING OFF)
+  set(BUILD_SHARED_LIBS OFF)
   set(ABSL_BUILD_TESTING OFF)
   set(ABSL_PROPAGATE_CXX_STD ON)
   set(ABSL_USE_SYSTEM_INCLUDES ON)
 
-  find_package(absl QUIET)
+  if(NURI_ENABLE_SANITIZERS)
+    message(
+      NOTICE
+      "abseil must be built with sanitizers enabled; ignoring system abseil"
+    )
+  else()
+    find_package(absl QUIET)
+  endif()
 
   # 20240116 required for VLOG()
   if(absl_FOUND AND absl_VERSION VERSION_GREATER_EQUAL 20240116)

--- a/cmake/NuriKitUtils.cmake
+++ b/cmake/NuriKitUtils.cmake
@@ -7,7 +7,6 @@ macro(_nuri_get_git_version_impl)
   find_package(Git)
 
   if(NOT Git_FOUND)
-    message(WARNING "Git not found!")
     return()
   endif()
 
@@ -161,7 +160,7 @@ function(find_or_fetch_pybind11)
     cmake_policy(SET CMP0148 NEW)
   endif()
 
-  find_package(pybind11 2.13)
+  find_package(pybind11 2.13 QUIET)
 
   if(pybind11_FOUND)
     message(STATUS "Found pybind11 ${pybind11_VERSION}")
@@ -186,7 +185,7 @@ function(handle_boost_dependency target)
     cmake_policy(SET CMP0167 NEW)
   endif()
 
-  find_package(Boost 1.82)
+  find_package(Boost 1.82 QUIET)
 
   if(Boost_FOUND)
     message(STATUS "Found Boost ${Boost_VERSION}")

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -17,11 +17,8 @@ else()
 endif()
 
 set(nuri_public_include_dirs "${NURI_INCLUDE_DIRECTORIES}")
-get_target_property(nuri_lib_include_dirs
-  nuri_lib INTERFACE_INCLUDE_DIRECTORIES)
-list(APPEND nuri_public_include_dirs
-  ${nuri_lib_include_dirs}
-  "${PROJECT_SOURCE_DIR}/third-party/abseil-cpp")
+get_target_property(nuri_lib_include_dirs nuri_lib INTERFACE_INCLUDE_DIRECTORIES)
+list(APPEND nuri_public_include_dirs ${nuri_lib_include_dirs})
 list(JOIN nuri_public_include_dirs " " NURI_INCLUDE_PATHS)
 
 set(DOXYGEN_IN ${CMAKE_CURRENT_LIST_DIR}/Doxyfile.in)

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -15,5 +15,3 @@ dependencies:
   - libabseil>=20240116.0
   - pybind11=2.13
   - pip
-  - pip:
-      - ".[docs]"

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -1,0 +1,19 @@
+#
+# Project NuriKit - Copyright 2024 SNU Compbio Lab.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: nurikit-docs
+channels:
+  - conda-forge
+dependencies:
+  - python=3.8
+  - cmake=3.16
+  - boost-cpp>=1.82
+  - eigen=3.4
+  - spectralib=1.0
+  - libabseil>=20240116.0
+  - pybind11=2.13
+  - pip
+  - pip:
+      - ".[docs]"

--- a/include/nuri/algo/optim.h
+++ b/include/nuri/algo/optim.h
@@ -13,9 +13,8 @@
 #include <functional>
 #include <utility>
 
-#include <Eigen/Dense>
-
 #include <absl/log/absl_check.h>
+#include <Eigen/Dense>
 /// @endcond
 
 #include "nuri/eigen_config.h"

--- a/include/nuri/core/bool_matrix.h
+++ b/include/nuri/core/bool_matrix.h
@@ -10,9 +10,8 @@
 #include <limits>
 #include <vector>
 
-#include <Eigen/Dense>
-
 #include <absl/base/optimization.h>
+#include <Eigen/Dense>
 /// @endcond
 
 #include "nuri/eigen_config.h"

--- a/include/nuri/core/geometry.h
+++ b/include/nuri/core/geometry.h
@@ -12,9 +12,8 @@
 #include <utility>
 #include <vector>
 
-#include <Eigen/Dense>
-
 #include <absl/log/absl_check.h>
+#include <Eigen/Dense>
 /// @endcond
 
 #include "nuri/eigen_config.h"

--- a/include/nuri/core/graph.h
+++ b/include/nuri/core/graph.h
@@ -17,14 +17,13 @@
 #include <utility>
 #include <vector>
 
-#include <boost/iterator/iterator_facade.hpp>
-#include <Eigen/Dense>
-
 #include <absl/algorithm/container.h>
 #include <absl/base/optimization.h>
 #include <absl/container/flat_hash_set.h>
 #include <absl/log/absl_check.h>
 #include <absl/log/absl_log.h>
+#include <boost/iterator/iterator_facade.hpp>
+#include <Eigen/Dense>
 /// @endcond
 
 #include "nuri/eigen_config.h"

--- a/include/nuri/core/molecule.h
+++ b/include/nuri/core/molecule.h
@@ -17,13 +17,12 @@
 #include <utility>
 #include <vector>
 
-#include <Eigen/Dense>
-
 #include <absl/algorithm/container.h>
 #include <absl/base/attributes.h>
 #include <absl/base/optimization.h>
 #include <absl/container/fixed_array.h>
 #include <absl/log/absl_check.h>
+#include <Eigen/Dense>
 /// @endcond
 
 #include "nuri/eigen_config.h"

--- a/include/nuri/eigen_config.h
+++ b/include/nuri/eigen_config.h
@@ -8,9 +8,8 @@
 /// @cond
 #include <type_traits>  // IWYU pragma: keep, required for is_class_v
 
-#include <Eigen/Dense>
-
 #include <absl/log/absl_check.h>
+#include <Eigen/Dense>
 /// @endcond
 
 #include "nuri/meta.h"

--- a/include/nuri/tools/tm.h
+++ b/include/nuri/tools/tm.h
@@ -10,9 +10,8 @@
 #include <cstdint>
 #include <utility>
 
-#include <Eigen/Dense>
-
 #include <absl/base/attributes.h>
+#include <Eigen/Dense>
 /// @endcond
 
 #include "nuri/eigen_config.h"

--- a/include/nuri/utils.h
+++ b/include/nuri/utils.h
@@ -24,14 +24,13 @@
 #include <utility>
 #include <vector>
 
-#include <boost/iterator/iterator_facade.hpp>
-#include <Eigen/Dense>
-
 #include <absl/algorithm/container.h>
 #include <absl/base/optimization.h>
 #include <absl/log/absl_check.h>
 #include <absl/numeric/bits.h>
 #include <absl/strings/ascii.h>
+#include <boost/iterator/iterator_facade.hpp>
+#include <Eigen/Dense>
 /// @endcond
 
 #include "nuri/eigen_config.h"

--- a/python/include/nuri/python/utils.h
+++ b/python/include/nuri/python/utils.h
@@ -17,17 +17,16 @@
 
 #include <object.h>
 #include <pyerrors.h>
+#include <absl/algorithm/container.h>
+#include <absl/log/absl_check.h>
+#include <absl/log/absl_log.h>
+#include <absl/strings/str_cat.h>
 #include <Eigen/Dense>
 #include <pybind11/attr.h>
 #include <pybind11/eigen.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
-
-#include <absl/algorithm/container.h>
-#include <absl/log/absl_check.h>
-#include <absl/log/absl_log.h>
-#include <absl/strings/str_cat.h>
 
 #include "nuri/eigen_config.h"
 #include "nuri/meta.h"

--- a/python/src/nuri/_log_interface_module.cpp
+++ b/python/src/nuri/_log_interface_module.cpp
@@ -3,10 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <pybind11/gil.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
-
 #include <absl/base/call_once.h>
 #include <absl/base/internal/raw_logging.h>
 #include <absl/base/log_severity.h>
@@ -17,6 +13,9 @@
 #include <absl/log/log_sink.h>
 #include <absl/log/log_sink_registry.h>
 #include <absl/log/vlog_is_on.h>
+#include <pybind11/gil.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
 
 #include "nuri/meta.h"
 

--- a/python/src/nuri/core/containers.cpp
+++ b/python/src/nuri/core/containers.cpp
@@ -10,13 +10,12 @@
 #include <utility>
 #include <vector>
 
+#include <absl/algorithm/container.h>
 #include <pybind11/attr.h>
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/typing.h>
-
-#include <absl/algorithm/container.h>
 
 #include "nuri/python/config.h"
 #include "nuri/python/utils.h"

--- a/python/src/nuri/core/element.cpp
+++ b/python/src/nuri/core/element.cpp
@@ -9,12 +9,11 @@
 #include <string_view>
 #include <vector>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
-
 #include <absl/strings/ascii.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_join.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
 
 #include "nuri/python/core/core_module.h"
 #include "nuri/python/utils.h"

--- a/python/src/nuri/core/geometry_module.cpp
+++ b/python/src/nuri/core/geometry_module.cpp
@@ -7,12 +7,11 @@
 #include <string_view>
 #include <utility>
 
+#include <absl/strings/str_cat.h>
 #include <Eigen/Dense>
 #include <pybind11/eigen.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
-
-#include <absl/strings/str_cat.h>
 
 #include "nuri/eigen_config.h"
 #include "nuri/core/geometry.h"

--- a/python/src/nuri/core/molecule.cpp
+++ b/python/src/nuri/core/molecule.cpp
@@ -12,6 +12,8 @@
 #include <utility>
 #include <vector>
 
+#include <absl/log/absl_log.h>
+#include <absl/strings/str_cat.h>
 #include <Eigen/Dense>
 #include <pybind11/attr.h>
 #include <pybind11/cast.h>
@@ -20,9 +22,6 @@
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>
 #include <pybind11/typing.h>
-
-#include <absl/log/absl_log.h>
-#include <absl/strings/str_cat.h>
 
 #include "nuri/eigen_config.h"
 #include "nuri/core/element.h"

--- a/python/src/nuri/core/substructure.cpp
+++ b/python/src/nuri/core/substructure.cpp
@@ -9,6 +9,8 @@
 #include <utility>
 #include <vector>
 
+#include <absl/cleanup/cleanup.h>
+#include <absl/strings/str_cat.h>
 #include <Eigen/Dense>
 #include <pybind11/cast.h>
 #include <pybind11/eigen.h>
@@ -16,9 +18,6 @@
 #include <pybind11/options.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
-
-#include <absl/cleanup/cleanup.h>
-#include <absl/strings/str_cat.h>
 
 #include "nuri/eigen_config.h"
 #include "nuri/core/graph.h"

--- a/python/src/nuri/fmt/fmt_module.cpp
+++ b/python/src/nuri/fmt/fmt_module.cpp
@@ -14,14 +14,13 @@
 #include <utility>
 #include <vector>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
-#include <pybind11/stl/filesystem.h>
-
 #include <absl/log/absl_log.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_join.h>
 #include <absl/types/span.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+#include <pybind11/stl/filesystem.h>
 
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/base.h"

--- a/python/src/nuri/tools/tm_module.cpp
+++ b/python/src/nuri/tools/tm_module.cpp
@@ -10,13 +10,12 @@
 #include <string_view>
 #include <utility>
 
+#include <absl/algorithm/container.h>
+#include <absl/strings/str_cat.h>
 #include <Eigen/Dense>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/typing.h>
-
-#include <absl/algorithm/container.h>
-#include <absl/strings/str_cat.h>
 
 #include "nuri/eigen_config.h"
 #include "nuri/python/utils.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,14 @@ target_link_libraries(nuri_lib
   absl::absl_check
   absl::absl_log
 )
-target_system_include_directories(nuri_lib Eigen3::Eigen Spectra::Spectra)
+target_system_include_directories(nuri_lib
+  Eigen3::Eigen
+  Spectra::Spectra
+  absl::strings
+  absl::flat_hash_map
+  absl::absl_log
+  absl::absl_check
+)
 handle_boost_dependency(nuri_lib)
 clear_coverage_data(nuri_lib)
 

--- a/src/algo/crdgen.cpp
+++ b/src/algo/crdgen.cpp
@@ -12,12 +12,11 @@
 #include <tuple>
 #include <vector>
 
-#include <Eigen/Dense>
-
 #include <absl/algorithm/container.h>
 #include <absl/base/attributes.h>
 #include <absl/log/absl_check.h>
 #include <absl/log/absl_log.h>
+#include <Eigen/Dense>
 
 #include "nuri/eigen_config.h"
 #include "nuri/algo/optim.h"

--- a/src/algo/guess/3d.cpp
+++ b/src/algo/guess/3d.cpp
@@ -11,8 +11,6 @@
 #include <utility>
 #include <vector>
 
-#include <Eigen/Dense>
-
 #include <absl/algorithm/container.h>
 #include <absl/base/optimization.h>
 #include <absl/container/fixed_array.h>
@@ -21,6 +19,7 @@
 #include <absl/container/inlined_vector.h>
 #include <absl/log/absl_check.h>
 #include <absl/log/absl_log.h>
+#include <Eigen/Dense>
 
 #include "nuri/eigen_config.h"
 #include "nuri/algo/guess.h"

--- a/src/algo/optim/bfgs.cpp
+++ b/src/algo/optim/bfgs.cpp
@@ -5,10 +5,9 @@
 
 #include <cmath>
 
-#include <Eigen/Dense>
-
 #include <absl/base/optimization.h>
 #include <absl/log/absl_log.h>
+#include <Eigen/Dense>
 
 #include "nuri/eigen_config.h"
 #include "nuri/algo/optim.h"

--- a/src/algo/optim/l_bfgs.cpp
+++ b/src/algo/optim/l_bfgs.cpp
@@ -8,10 +8,9 @@
 #include <utility>
 #include <vector>
 
-#include <Eigen/Dense>
-
 #include <absl/base/optimization.h>
 #include <absl/log/absl_check.h>
+#include <Eigen/Dense>
 
 #include "nuri/eigen_config.h"
 #include "nuri/algo/optim.h"

--- a/src/core/geometry/align.cpp
+++ b/src/core/geometry/align.cpp
@@ -7,9 +7,8 @@
 #include <cstdlib>
 #include <utility>
 
-#include <Eigen/Dense>
-
 #include <absl/base/optimization.h>
+#include <Eigen/Dense>
 
 #include "nuri/eigen_config.h"
 #include "nuri/core/geometry.h"

--- a/src/core/geometry/embed.cpp
+++ b/src/core/geometry/embed.cpp
@@ -6,13 +6,12 @@
 #include <algorithm>
 #include <exception>
 
+#include <absl/log/absl_log.h>
 #include <Eigen/Dense>
 #include <Spectra/MatOp/DenseSymMatProd.h>
 #include <Spectra/SymEigsSolver.h>
 #include <Spectra/Util/CompInfo.h>
 #include <Spectra/Util/SelectionRule.h>
-
-#include <absl/log/absl_log.h>
 
 #include "nuri/eigen_config.h"
 #include "nuri/core/geometry.h"

--- a/src/core/geometry/octree.cpp
+++ b/src/core/geometry/octree.cpp
@@ -9,9 +9,8 @@
 #include <utility>
 #include <vector>
 
-#include <Eigen/Dense>
-
 #include <absl/log/absl_log.h>
+#include <Eigen/Dense>
 
 #include "nuri/eigen_config.h"
 #include "nuri/core/geometry.h"

--- a/src/core/molecule/molecule.cpp
+++ b/src/core/molecule/molecule.cpp
@@ -12,12 +12,11 @@
 #include <utility>
 #include <vector>
 
-#include <Eigen/Dense>
-
 #include <absl/base/optimization.h>
 #include <absl/container/fixed_array.h>
 #include <absl/container/flat_hash_set.h>
 #include <absl/log/absl_log.h>
+#include <Eigen/Dense>
 
 #include "nuri/eigen_config.h"
 #include "nuri/core/element.h"

--- a/src/core/molecule/mutator.cpp
+++ b/src/core/molecule/mutator.cpp
@@ -9,9 +9,8 @@
 #include <utility>
 #include <vector>
 
-#include <Eigen/Dense>
-
 #include <absl/log/absl_check.h>
+#include <Eigen/Dense>
 
 #include "nuri/eigen_config.h"
 #include "nuri/core/graph.h"

--- a/src/core/molecule/sanitizer.cpp
+++ b/src/core/molecule/sanitizer.cpp
@@ -9,8 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include <Eigen/Dense>
-
 #include <absl/base/optimization.h>
 #include <absl/container/fixed_array.h>
 #include <absl/container/flat_hash_map.h>
@@ -18,6 +16,7 @@
 #include <absl/log/absl_check.h>
 #include <absl/log/absl_log.h>
 #include <absl/strings/str_cat.h>
+#include <Eigen/Dense>
 
 #include "nuri/algo/rings.h"
 #include "nuri/core/element.h"

--- a/src/fmt/mol2.cpp
+++ b/src/fmt/mol2.cpp
@@ -15,11 +15,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/fusion/include/std_pair.hpp>
-#include <boost/fusion/include/std_tuple.hpp>
-#include <boost/optional.hpp>
-#include <boost/spirit/home/x3.hpp>
-
 #include <absl/algorithm/container.h>
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/inlined_vector.h>
@@ -31,6 +26,10 @@
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_split.h>
+#include <boost/fusion/include/std_pair.hpp>
+#include <boost/fusion/include/std_tuple.hpp>
+#include <boost/optional.hpp>
+#include <boost/spirit/home/x3.hpp>
 
 #include "nuri/eigen_config.h"
 #include "fmt_internal.h"

--- a/src/fmt/pdb.cpp
+++ b/src/fmt/pdb.cpp
@@ -19,8 +19,6 @@
 #include <utility>
 #include <vector>
 
-#include <Eigen/Dense>
-
 #include <absl/algorithm/container.h>
 #include <absl/base/optimization.h>
 #include <absl/container/fixed_array.h>
@@ -33,6 +31,7 @@
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
+#include <Eigen/Dense>
 
 #include "nuri/eigen_config.h"
 #include "nuri/algo/guess.h"

--- a/src/fmt/sdf.cpp
+++ b/src/fmt/sdf.cpp
@@ -15,10 +15,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/fusion/include/std_pair.hpp>
-#include <boost/fusion/include/std_tuple.hpp>
-#include <boost/spirit/home/x3.hpp>
-
 #include <absl/algorithm/container.h>
 #include <absl/base/optimization.h>
 #include <absl/container/inlined_vector.h>
@@ -34,6 +30,9 @@
 #include <absl/strings/strip.h>
 #include <absl/time/clock.h>
 #include <absl/time/time.h>
+#include <boost/fusion/include/std_pair.hpp>
+#include <boost/fusion/include/std_tuple.hpp>
+#include <boost/spirit/home/x3.hpp>
 
 #include "nuri/eigen_config.h"
 #include "fmt_internal.h"

--- a/src/fmt/smiles.cpp
+++ b/src/fmt/smiles.cpp
@@ -17,11 +17,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/fusion/include/at_c.hpp>
-#include <boost/fusion/include/deque.hpp>
-#include <boost/iterator/counting_iterator.hpp>
-#include <boost/spirit/home/x3.hpp>
-
 #include <absl/algorithm/container.h>
 #include <absl/base/attributes.h>
 #include <absl/base/optimization.h>
@@ -33,6 +28,10 @@
 #include <absl/strings/ascii.h>
 #include <absl/strings/str_cat.h>
 #include <absl/types/span.h>
+#include <boost/fusion/include/at_c.hpp>
+#include <boost/fusion/include/deque.hpp>
+#include <boost/iterator/counting_iterator.hpp>
+#include <boost/spirit/home/x3.hpp>
 
 #include "nuri/eigen_config.h"
 #include "nuri/core/element.h"

--- a/src/tools/tm.cpp
+++ b/src/tools/tm.cpp
@@ -11,12 +11,11 @@
 #include <tuple>
 #include <utility>
 
-#include <Eigen/Dense>
-
 #include <absl/algorithm/container.h>
 #include <absl/base/optimization.h>
 #include <absl/log/absl_check.h>
 #include <absl/log/absl_log.h>
+#include <Eigen/Dense>
 
 #include "nuri/eigen_config.h"
 #include "nuri/core/geometry.h"

--- a/test/algo/crdgen_test.cpp
+++ b/test/algo/crdgen_test.cpp
@@ -5,11 +5,11 @@
 
 #include "nuri/algo/crdgen.h"
 
-#include <Eigen/Dense>
-
 #include <absl/algorithm/container.h>
 #include <absl/base/attributes.h>
 #include <absl/log/absl_check.h>
+#include <Eigen/Dense>
+
 #include <gtest/gtest.h>
 
 #include "nuri/eigen_config.h"

--- a/test/algo/guess_test.cpp
+++ b/test/algo/guess_test.cpp
@@ -12,6 +12,7 @@
 #include <absl/algorithm/container.h>
 #include <absl/strings/ascii.h>
 #include <absl/strings/str_split.h>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/test/algo/optim/l_bfgs_test.cpp
+++ b/test/algo/optim/l_bfgs_test.cpp
@@ -5,12 +5,12 @@
 
 #include <vector>
 
-#include <Eigen/Dense>
-
 #include <absl/algorithm/container.h>
 #include <absl/base/attributes.h>
 #include <absl/base/optimization.h>
 #include <absl/log/absl_check.h>
+#include <Eigen/Dense>
+
 #include <gtest/gtest.h>
 
 #include "nuri/eigen_config.h"

--- a/test/algo/rings_test.cpp
+++ b/test/algo/rings_test.cpp
@@ -12,6 +12,7 @@
 #include <absl/container/flat_hash_set.h>
 #include <absl/log/absl_check.h>
 #include <absl/strings/str_join.h>
+
 #include <gtest/gtest.h>
 
 #include "nuri/core/molecule.h"

--- a/test/core/extra_test.cpp
+++ b/test/core/extra_test.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include <absl/algorithm/container.h>
+
 #include <gtest/gtest.h>
 
 #include "nuri/core/bool_matrix.h"

--- a/test/core/geometry_test.cpp
+++ b/test/core/geometry_test.cpp
@@ -8,9 +8,9 @@
 #include <algorithm>
 #include <vector>
 
+#include <absl/strings/str_cat.h>
 #include <Eigen/Dense>
 
-#include <absl/strings/str_cat.h>
 #include <gtest/gtest.h>
 
 #include "nuri/eigen_config.h"

--- a/test/core/graph_test.cpp
+++ b/test/core/graph_test.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <absl/container/flat_hash_set.h>
+
 #include <gtest/gtest.h>
 
 #define NURI_TEST_CONVERTIBILITY(from_name, from_expr, to_name, to_expr,       \

--- a/test/core/molecule_substructure_test.cpp
+++ b/test/core/molecule_substructure_test.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <absl/algorithm/container.h>
+
 #include <gtest/gtest.h>
 
 #include "nuri/core/graph.h"

--- a/test/core/molecule_test.cpp
+++ b/test/core/molecule_test.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <absl/algorithm/container.h>
+
 #include <gtest/gtest.h>
 
 #include "nuri/eigen_config.h"

--- a/test/fmt/mol2_test.cpp
+++ b/test/fmt/mol2_test.cpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include <absl/strings/str_cat.h>
+
 #include <gtest/gtest.h>
 
 #include "fmt_test_common.h"

--- a/test/fmt/pdb_test.cpp
+++ b/test/fmt/pdb_test.cpp
@@ -11,6 +11,7 @@
 
 #include <absl/algorithm/container.h>
 #include <absl/strings/match.h>
+
 #include <gtest/gtest.h>
 
 #include "fmt_test_common.h"

--- a/test/fmt/sdf_test.cpp
+++ b/test/fmt/sdf_test.cpp
@@ -9,6 +9,7 @@
 #include <absl/strings/match.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_split.h>
+
 #include <gtest/gtest.h>
 
 #include "nuri/eigen_config.h"

--- a/test/tools/tm_test.cpp
+++ b/test/tools/tm_test.cpp
@@ -8,10 +8,10 @@
 #include <cmath>
 #include <string_view>
 
-#include <Eigen/Dense>
-
 #include <absl/base/optimization.h>
 #include <absl/log/absl_check.h>
+#include <Eigen/Dense>
+
 #include <gtest/gtest.h>
 
 #include "nuri/eigen_config.h"

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -6,8 +6,4 @@
 # Don't fail build on warnings from third-party code.
 add_compile_options(-Wno-error)
 
-set(ABSL_PROPAGATE_CXX_STD ON)
-set(ABSL_USE_SYSTEM_INCLUDES ON)
-add_subdirectory("abseil-cpp")
-
 add_subdirectory("googletest")


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Does all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

---

<!-- Start the description of the PR here -->
