### PR TITLE
build: enable downloading prebuilt absl binaries

### DIFF
--- a/.github/workflows/_wheel-build.yaml
+++ b/.github/workflows/_wheel-build.yaml
@@ -33,6 +33,12 @@ jobs:
       - if: ${{ contains(inputs.python, 'macosx') }}
         run: brew install eigen spectra boost pybind11 ninja
 
+      - if: ${{ contains(inputs.python, 'macosx') }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          # XCode 15.4 fails to build abseil correctly
+          xcode-version: latest-stable
+
       # https://github.com/pypa/cibuildwheel/issues/954
       - if: ${{ inputs.python == 'cp38-macosx_arm64' }}
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(NURI_ENABLE_AVX2 "Use -mavx2 flag for optimization" OFF)
 option(NURI_ENABLE_ARCH_NATIVE "Use -march=native flag for optimization" OFF)
 
 option(NURI_ENABLE_SANITIZERS "Enable sanitizers for debug build" OFF)
+option(NURI_PREBUILT_ABSL "Download prebuilt abseil binary" ON)
 
 option(NURI_TEST_COVERAGE "Enable coverage build" OFF)
 option(NURI_BUILD_DOCS "Build documentation" OFF)
@@ -112,8 +113,8 @@ if(CMAKE_BUILD_TYPE MATCHES "Release|MinSizeRel")
   add_link_options(-s)
 endif()
 
-add_subdirectory(third-party EXCLUDE_FROM_ALL)
 find_or_fetch_abseil()
+add_subdirectory(third-party EXCLUDE_FROM_ALL)
 
 add_compile_options(
   -pedantic


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Does all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #...

---

<!-- Start the description of the PR here -->
