### PR TITLE
fix(python/fmt/cif): pass internal reference to subobject and support inconsistent CIF files

### DIFF
--- a/python/include/nuri/python/utils.h
+++ b/python/include/nuri/python/utils.h
@@ -493,7 +493,9 @@ py::class_<T> &add_sequence_interface(py::class_<T> &cls, Size size,
   cls.def("__len__", size);
   cls.def(
       "__contains__",
-      [size](T &self, int idx) { return 0 <= idx && idx < size(self); },
+      [size](T &self, int idx) {
+        return 0 <= idx && idx < std::invoke(size, self);
+      },
       py::arg("idx"));
   cls.def("__getitem__", std::forward<Getter>(getter), kReturnsSubobject,
           py::arg("idx"));

--- a/python/src/nuri/fmt/cif.cpp
+++ b/python/src/nuri/fmt/cif.cpp
@@ -313,11 +313,11 @@ Search for the first table containing a column starting with the given prefix.
   bind_opaque_vector<internal::CifFrame, PyCifFrame, wrap_cif_frame>(
       m, "_CifFrameList", "_CifFrameList index out of range");
 
-  py::class_<PyCifBlock>(m, "CifBlock")  //
-      .def_property_readonly("data", &PyCifBlock::data)
-      .def_property_readonly("name", &PyCifBlock::name)
-      .def_property_readonly("save_frames", &PyCifBlock::save_frames)
-      .def_property_readonly("is_global", &PyCifBlock::is_global);
+  py::class_<PyCifBlock> cb(m, "CifBlock");
+  cb.def_property_readonly("name", &PyCifBlock::name)
+      .def_property_readonly("is_global", &PyCifBlock::is_global)
+      .def_property_readonly("save_frames", &PyCifBlock::save_frames);
+  def_property_readonly_subobject(cb, "data", &PyCifBlock::data);
 
   py::class_<PyCifParser>(m, "CifParser")
       .def("__iter__", pass_through<PyCifParser>)

--- a/python/test/fmt/cif_test.py
+++ b/python/test/fmt/cif_test.py
@@ -81,6 +81,11 @@ def test_read_cif(test_data: Path):
     assert nonexistent is None
 
 
+def test_read_cif_temporary(test_data: Path):
+    data = next(read_cif(test_data / "1a8o.cif")).data
+    assert data.name == "1A8O"
+
+
 def test_convert_ddl2_cif(test_data: Path):
     cif = test_data / "1a8o.cif"
 


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Do all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [x] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

---

<!-- Start the description of the PR here -->
