### PR TITLE
fix(fmt/mmcif): avoid insert() function

### DIFF
--- a/python/test/fmt/mmcif_test.py
+++ b/python/test/fmt/mmcif_test.py
@@ -32,7 +32,10 @@ def _validate_3cye_part(mols: List[Molecule]):
     assert mol.subs[0].name == "VAL"
     assert mol.subs[0].num_atoms() == 7
 
+    assert mol.subs[8].id == 169
+    assert mol.subs[8].props["chain"] == "A"
     assert mol.subs[8].props["icode"] == "A"
+    assert mol.subs[8].props["entity_id"] == "1"
 
     mol = mols[1]
     assert mol.name == "3CYE"

--- a/python/test/fmt/pdb_test.py
+++ b/python/test/fmt/pdb_test.py
@@ -57,8 +57,10 @@ def _verify_mols(mols: List[Molecule]):
         elif sub.category == SubstructureCategory.Residue:
             if sub.id == 2:
                 assert sub.name == "GLU"
+                assert sub.props["chain"] == "A"
             elif sub.id == 3:
                 assert sub.name == "ASN"
+                assert sub.props["chain"] == "B"
             else:
                 pytest.fail("Invalid residue ID")
         else:

--- a/src/fmt/mmcif.cpp
+++ b/src/fmt/mmcif.cpp
@@ -450,7 +450,7 @@ public:
     ABSL_DCHECK(static_cast<bool>(info));
 
     ResidueId id = info.id().res;
-    auto [it, first] = map_.insert({ id, data_.size() });
+    auto [it, first] = map_.emplace(id, data_.size());
 
     if (first) {
       data_.push_back({ it->first, comp_id, {} });


### PR DESCRIPTION
See conda-forge/nurikit-feedstock#9 for context.

## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [ ] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [ ] Have you built the project locally without any warnings and errors?
- [ ] Do all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #...

---

<!-- Start the description of the PR here -->

With GCC and shared abseil library, insert() member function produces invalid data (root cause not found yet).
Using `emplace()` instead is a workaround, but works.

Found in conda-forge/nurikit-feedstock#9.