### PR TITLE
feat(core/graph): switch to CSR format

### DIFF
--- a/include/nuri/core/graph/adaptor.h
+++ b/include/nuri/core/graph/adaptor.h
@@ -303,6 +303,9 @@ void remove_vertex(
   g.erase_nodes(g.begin() + v, g.begin() + v + 1);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 template <class NT, class ET>
 auto add_edge(typename boost::graph_traits<Graph<NT, ET>>::vertex_descriptor u,
               typename boost::graph_traits<Graph<NT, ET>>::vertex_descriptor v,
@@ -312,6 +315,8 @@ auto add_edge(typename boost::graph_traits<Graph<NT, ET>>::vertex_descriptor u,
       typename boost::graph_traits<Graph<NT, ET>>::edge_descriptor { e, u, v },
       true);
 }
+
+#pragma GCC diagnostic pop
 
 template <class NT, class ET>
 void remove_edge(

--- a/include/nuri/core/graph/graph.h
+++ b/include/nuri/core/graph/graph.h
@@ -1323,13 +1323,13 @@ void Graph<NT, ET>::publish_edges_from(const int first_eid) {
 
   // Phase 1: count per-node delta from just the new edges; track v_min.
   std::vector<int> delta(n, 0);
-  int v_min = n;
   for (int eid = first_eid; eid < total_edges; ++eid) {
     const StoredEdge &e = edges_[eid];
     ++delta[e.src];
     ++delta[e.dst];
-    v_min = std::min({ v_min, e.src, e.dst });
   }
+  const int v_min = static_cast<int>(
+      absl::c_find_if(delta, [](int d) { return d > 0; }) - delta.begin());
 
   // Phase 2: grow the flat buffer by the total number of new endpoints.
   const int added = 2 * (total_edges - first_eid);
@@ -1359,17 +1359,12 @@ void Graph<NT, ET>::publish_edges_from(const int first_eid) {
       << "shift mismatch: " << shift << " vs " << delta[v_min];
   // GCOV_EXCL_STOP
 
-  // Phase 4: repurpose delta[] as per-node write cursors, each pointing at the
-  // start of its node's "gap" in the new layout:
-  //   cursor[v] = new_offsets[v+1] - delta[v] = new_offsets[v] + old_degree[v].
-  for (int v = v_min; v < n; ++v)
-    delta[v] = offsets_[v + 1] - delta[v];
-
-  // Phase 5: place new adjacency entries in eid order.
+  // Phase 4: place new adjacency entries in eid order.
   for (int eid = first_eid; eid < total_edges; ++eid) {
     const StoredEdge &e = edges_[eid];
-    adj_list_[delta[e.src]++] = { e.dst, eid };
-    adj_list_[delta[e.dst]++] = { e.src, eid };
+    int sd = delta[e.src]--, dd = delta[e.dst]--;
+    adj_list_[offsets_[e.src + 1] - sd] = { e.dst, eid };
+    adj_list_[offsets_[e.dst + 1] - dd] = { e.src, eid };
   }
 }
 

--- a/include/nuri/core/graph/graph.h
+++ b/include/nuri/core/graph/graph.h
@@ -440,6 +440,17 @@ namespace internal {
 
   template <class, bool>
   class SubEdgeWrapper;
+
+  template <class T>
+  struct OffsetForwarder {
+    template <class U>
+    T operator()(const U &edge) const {
+      return T { edge.src().id() + offset, edge.dst().id() + offset,
+                 edge.data() };
+    }
+
+    int offset;
+  };
 }  // namespace internal
 
 using NodesErased = std::pair<std::pair<int, std::vector<int>>,
@@ -1058,10 +1069,7 @@ public:
     auto edges = other.edges();
     reserve_edges(num_edges() + edges.size());
 
-    auto as_stored_edge = [offset](const auto &edge) {
-      return StoredEdge { edge.src().id() + offset, edge.dst().id() + offset,
-                          edge.data() };
-    };
+    internal::OffsetForwarder<StoredEdge> as_stored_edge { offset };
     add_edges(internal::make_transform_iterator(edges.begin(), as_stored_edge),
               internal::make_transform_iterator(edges.end(), as_stored_edge));
   }

--- a/include/nuri/core/graph/graph.h
+++ b/include/nuri/core/graph/graph.h
@@ -608,10 +608,13 @@ public:
    * @param dst The destination node id.
    * @param data The data to copy-construct the edge with.
    * @return The id of the newly added edge.
-   * @note Time complexity: \f$O(N)\f$ amortized.
+   * @note Time complexity: \f$O(V+E)\f$ in the worst case; \f$O(V-v_\min)\f$
+   *       when \f$v_\min = \min(\mathtt{src}, \mathtt{dst})\f$ is at least the
+   *       number of nodes that existed before the last edge addition (the
+   *       merge() hot path).
    * @note If \p src or \p dst is out of range, \p src equals \p dst, or an edge
    *       between \p src and \p dst already exists, the behavior is undefined.
-   * @deprecated Slow, due to CSR recompilation.
+   * @deprecated Slow, due to CSR recompilation; prefer add_edges() / merge().
    */
   ABSL_DEPRECATED("Slow, due to CSR recompilation.")
   int add_edge(int src, int dst, const ET &data) {
@@ -629,10 +632,10 @@ public:
    * @param dst The destination node id.
    * @param data The data to move-construct the edge with.
    * @return The id of the newly added edge.
-   * @note Time complexity: \f$O(N)\f$ amortized.
+   * @note Time complexity: same as add_edge(int, int, const ET&).
    * @note If \p src or \p dst is out of range, \p src equals \p dst, or an edge
    *       between \p src and \p dst already exists, the behavior is undefined.
-   * @deprecated Slow, due to CSR recompilation.
+   * @deprecated Slow, due to CSR recompilation; prefer add_edges() / merge().
    */
   ABSL_DEPRECATED("Slow, due to CSR recompilation.")
   int add_edge(int src, int dst, ET &&data) noexcept {
@@ -651,7 +654,10 @@ public:
    *         `StoredEdge`.
    * @param begin The beginning of the range of edges to be added.
    * @param end The end of the range of edges to be added.
-   * @note Time complexity: \f$O(E)\f$.
+   * @note Time complexity: \f$O(V + E')\f$ in general, where \f$E'\f$ is the
+   *       length of `[begin, end)`. Degenerates to \f$O(E')\f$ when every new
+   *       edge's endpoints are among the nodes added since the last edge
+   *       publish (the merge() hot path).
    */
   template <class Iterator,
             internal::enable_if_compatible_iter_t<Iterator, StoredEdge> = 0>
@@ -683,10 +689,14 @@ public:
    * @param id The id of the node to be erased.
    * @return The data of the erased node.
    * @sa erase_nodes()
-   * @note Time complexity: \f$O(V)\f$ if only trailing node is erased,
-   *       \f$O(V+E)\f$ otherwise.
+   * @note Time complexity: \f$O(V+E)\f$.
    * @note If \p id is out of range, the behavior is undefined.
+   * @deprecated Slow, due to CSR compaction. Prefer erase_nodes() for batch
+   *             node erasure.
    */
+  ABSL_DEPRECATED(
+      "Slow, due to CSR compaction. Prefer erase_nodes() for batch node "
+      "erasure.");
   NT pop_node(int id) {
     NT ret = std::move(nodes_[id]);
     erase_nodes(begin() + id, begin() + id + 1);
@@ -709,10 +719,8 @@ public:
    *         applies to edges.
    * @sa pop_node()
    * @note Time complexity:
-   *         1. \f$O(N)\f$ if no nodes are erased,
-   *         2. \f$O(V)\f$ if only trailing nodes are erased and no edges are
-   *            erased,
-   *         3. \f$O(V+E)\f$ otherwise.
+   *         1. \f$O(V)\f$ if no nodes are erased,
+   *         2. \f$O(V+E)\f$ otherwise.
    * @note If any of the iterators in range `[`\p begin, \p end`)` is out of
    *       range, the behavior is undefined.
    */
@@ -796,7 +804,7 @@ public:
    * @param src The source node id.
    * @param dst The destination node id.
    * @return Iterator to the edge if found, otherwise the end iterator.
-   * @note Time complexity: \f$O(V/E)\f$.
+   * @note Time complexity: \f$O(E/V)\f$.
    * @note If \p src or \p dst is out of range, the behavior is undefined.
    */
   edge_iterator find_edge(int src, int dst) {
@@ -859,7 +867,10 @@ public:
    * @sa erase_edge(), erase_edge_between(), erase_edges()
    * @note Time complexity: same as erase_edge().
    * @note If \p id is out of range, the behavior is undefined.
+   * @deprecated Slow, due to CSR compaction; prefer erase_edges() for bulk
+   *             removal.
    */
+  ABSL_DEPRECATED("Slow, due to CSR compaction; prefer erase_edges().")
   ET pop_edge(int id) {
     ET ret = std::move(edges_[id].data);
     erase_edge(id);
@@ -871,10 +882,12 @@ public:
    *
    * @param id The id of the edge to be erased.
    * @sa pop_edge(), erase_edge_between(), erase_edges()
-   * @note Time complexity: \f$O(E/V)\f$ if the edge is the last edge,
-   *       \f$O(V+E)\f$ otherwise.
+   * @note Time complexity: \f$O(V+E)\f$.
    * @note If \p id is out of range, the behavior is undefined.
+   * @deprecated Slow, due to CSR compaction; prefer erase_edges() for bulk
+   *             removal.
    */
+  ABSL_DEPRECATED("Slow, due to CSR compaction; prefer erase_edges().")
   void erase_edge(int id) {
     const StoredEdge &edge = edges_[id];
     auto srcit = find_adjacency_entry(edge.src, edge.dst),
@@ -893,7 +906,10 @@ public:
    * @sa pop_edge(), erase_edge(), erase_edges()
    * @note Time complexity: same as erase_edge().
    * @note If \p src or \p dst is out of range, the behavior is undefined.
+   * @deprecated Slow, due to CSR compaction; prefer erase_edges() for bulk
+   *             removal.
    */
+  ABSL_DEPRECATED("Slow, due to CSR compaction; prefer erase_edges().")
   bool erase_edge_between(int src, int dst);
 
   /**
@@ -906,7 +922,10 @@ public:
    * @note Time complexity: same as erase_edge().
    * @note If \p src or \p dst does not belong to this graph, the behavior is
    *       undefined.
+   * @deprecated Slow, due to CSR compaction; prefer erase_edges() for bulk
+   *             removal.
    */
+  ABSL_DEPRECATED("Slow, due to CSR compaction; prefer erase_edges().")
   bool erase_edge_between(ConstNodeRef src, ConstNodeRef dst) {
     return erase_edge_between(src.id(), dst.id());
   }
@@ -924,7 +943,7 @@ public:
    *         before this operation. Otherwise, `new end id` will be set to -1
    *         and erased edges will be marked as -1 in the mapping.
    * @sa pop_edge(), erase_edge(), erase_edge_between()
-   * @note Time complexity: \f$O(N)\f$ if no edges were removed, \f$O(V+E)\f$
+   * @note Time complexity: \f$O(E)\f$ if no edges were removed, \f$O(V+E)\f$
    *       otherwise.
    * @note If any of the iterators in range `[`\p begin, \p end`)` is out of
    *       range, the behavior is undefined.
@@ -1002,7 +1021,7 @@ public:
    * @param dst The destination node id.
    * @return Iterator to the adjacency entry if found, otherwise the end
    *         iterator of the adjacency list of \p src.
-   * @note Time complexity: \f$O(V/E)\f$.
+   * @note Time complexity: \f$O(E/V)\f$.
    * @note If \p src or \p dst is out of range, the behavior is undefined.
    */
   adjacency_iterator find_adjacent(int src, int dst) {
@@ -1015,7 +1034,7 @@ public:
    * @param dst The destination node id.
    * @return Iterator to the adjacency entry if found, otherwise the end
    *         iterator of the adjacency list of \p src.
-   * @note Time complexity: \f$O(V/E)\f$.
+   * @note Time complexity: \f$O(E/V)\f$.
    * @note If \p src or \p dst is out of range, the behavior is undefined.
    */
   const_adjacency_iterator find_adjacent(int src, int dst) const {
@@ -1028,7 +1047,7 @@ public:
    * @param dst The destination node.
    * @return Iterator to the adjacency entry if found, otherwise the end
    *         iterator of the adjacency list of \p src.
-   * @note Time complexity: \f$O(V/E)\f$.
+   * @note Time complexity: \f$O(E/V)\f$.
    * @note If \p src or \p dst does not belong to this graph, the behavior is
    *       undefined.
    */
@@ -1042,7 +1061,7 @@ public:
    * @param dst The destination node.
    * @return Iterator to the adjacency entry if found, otherwise the end
    *         iterator of the adjacency list of \p src.
-   * @note Time complexity: \f$O(V/E)\f$.
+   * @note Time complexity: \f$O(E/V)\f$.
    * @note If \p src or \p dst does not belong to this graph, the behavior is
    *       undefined.
    */
@@ -1148,9 +1167,10 @@ private:
    *
    * @note Complexity: `O((V - v_min) + (E_total - first_eid))`, where
    *       `v_min` is the smallest endpoint among the new edges. Degenerates
-   *       to `O(E_total - first_eid)` when every new edge's endpoints are
-   *       `>= num_nodes()` at the time of the last rebuild (the merge() hot
-   *       path).
+   *       to `O(E_total - first_eid)` in the merge() hot path, i.e. when
+   *       every new edge's endpoints are among the nodes added since the
+   *       previous publish (so their adjacency slices are all empty and no
+   *       existing entries need to be shifted).
    */
   void publish_edges_from(int first_eid);
 
@@ -1300,9 +1320,9 @@ Graph<NT, ET>::erase_nodes_common(std::vector<int> &node_keep,
 
   // Phase III: erase the nodes & adjacencies
   if (erase_trailing) {
-    // Fast path 2: if only trailing nodes are erased, no node number needs to
-    // be updated.
-    ABSL_DLOG(INFO) << "resizing adjacency & node list";
+    // Fast path 2: only trailing nodes with incident edges; the edge erase
+    // above already compacted adj_list_, so just trim nodes_/offsets_.
+    ABSL_DLOG(INFO) << "resizing offset table & node list";
     // O(1) operations
     nodes_.resize(first_erased_id);
     offsets_.resize(first_erased_id + 1);
@@ -1438,7 +1458,7 @@ Graph<NT, ET>::erase_edges(const_edge_iterator begin, const_edge_iterator end,
   if (begin >= end)
     return { num_edges(), {} };
 
-  // Phase I: mark edges for removal, O(N)
+  // Phase I: mark edges for removal, O(E)
   std::vector<int> edge_keep(num_edges(), 1);
   int first_erased_id = -1;
   bool erase_trailing = end == this->edge_end();
@@ -1468,7 +1488,7 @@ std::pair<int, std::vector<int>> Graph<NT, ET>::erase_edges(Iterator begin,
   if (begin == end)
     return { num_edges(), {} };
 
-  // Phase I: mark edges for removal, O(N)
+  // Phase I: mark edges for removal, O(E)
   std::vector<int> edge_keep(num_edges(), 1);
   int first_erased_id = num_edges();
   for (auto it = begin; it != end; ++it) {

--- a/include/nuri/core/graph/graph.h
+++ b/include/nuri/core/graph/graph.h
@@ -684,26 +684,6 @@ public:
   }
 
   /**
-   * @brief Erase a node and all its associated edge(s) from the graph.
-   *
-   * @param id The id of the node to be erased.
-   * @return The data of the erased node.
-   * @sa erase_nodes()
-   * @note Time complexity: \f$O(V+E)\f$.
-   * @note If \p id is out of range, the behavior is undefined.
-   * @deprecated Slow, due to CSR compaction. Prefer erase_nodes() for batch
-   *             node erasure.
-   */
-  ABSL_DEPRECATED(
-      "Slow, due to CSR compaction. Prefer erase_nodes() for batch node "
-      "erasure.");
-  NT pop_node(int id) {
-    NT ret = std::move(nodes_[id]);
-    erase_nodes(begin() + id, begin() + id + 1);
-    return ret;
-  }
-
-  /**
    * @brief Erase nodes and all its associated edge(s) from the graph.
    *
    * @param begin The beginning of the range of nodes to be erased.
@@ -717,7 +697,6 @@ public:
    *         before this operation. Otherwise, `new end id` will be set to -1
    *         and erased nodes will be marked as -1 in the mapping. The same rule
    *         applies to edges.
-   * @sa pop_node()
    * @note Time complexity:
    *         1. \f$O(V)\f$ if no nodes are erased,
    *         2. \f$O(V+E)\f$ otherwise.
@@ -746,7 +725,6 @@ public:
    *         before this operation. Otherwise, `new end id` will be set to -1
    *         and erased nodes will be marked as -1 in the mapping. The same rule
    *         applies to edges.
-   * @sa pop_node()
    * @note Time complexity: same as erase_nodes(const_iterator, const_iterator).
    * @note If any of the iterators in range `[`\p begin, \p end`)` is out of
    *       range, the behavior is undefined.
@@ -771,7 +749,6 @@ public:
    *         before this operation. Otherwise, `new end id` will be set to -1
    *         and erased nodes will be marked as -1 in the mapping. The same rule
    *         applies to edges.
-   * @sa pop_node()
    * @note Time complexity: same as erase_nodes(const_iterator, const_iterator).
    * @note If any of the iterators in range `[`\p begin, \p end`)` points to an
    *       invalid node id, the behavior is undefined.
@@ -863,31 +840,10 @@ public:
    * @brief Erase an edge from the graph.
    *
    * @param id The id of the edge to be erased.
-   * @return The data of the erased edge.
-   * @sa erase_edge(), erase_edge_between(), erase_edges()
-   * @note Time complexity: same as erase_edge().
-   * @note If \p id is out of range, the behavior is undefined.
-   * @deprecated Slow, due to CSR compaction; prefer erase_edges() for bulk
-   *             removal.
-   */
-  ABSL_DEPRECATED("Slow, due to CSR compaction; prefer erase_edges().")
-  ET pop_edge(int id) {
-    ET ret = std::move(edges_[id].data);
-    erase_edge(id);
-    return ret;
-  }
-
-  /**
-   * @brief Erase an edge from the graph.
-   *
-   * @param id The id of the edge to be erased.
-   * @sa pop_edge(), erase_edge_between(), erase_edges()
+   * @sa erase_edge_between(), erase_edges()
    * @note Time complexity: \f$O(V+E)\f$.
    * @note If \p id is out of range, the behavior is undefined.
-   * @deprecated Slow, due to CSR compaction; prefer erase_edges() for bulk
-   *             removal.
    */
-  ABSL_DEPRECATED("Slow, due to CSR compaction; prefer erase_edges().")
   void erase_edge(int id) {
     const StoredEdge &edge = edges_[id];
     auto srcit = find_adjacency_entry(edge.src, edge.dst),
@@ -903,13 +859,10 @@ public:
    * @param src The source node, interchangeable with \p dst.
    * @param dst The destination node, interchangeable with \p src.
    * @return Whether the edge is erased.
-   * @sa pop_edge(), erase_edge(), erase_edges()
+   * @sa erase_edge(), erase_edges()
    * @note Time complexity: same as erase_edge().
    * @note If \p src or \p dst is out of range, the behavior is undefined.
-   * @deprecated Slow, due to CSR compaction; prefer erase_edges() for bulk
-   *             removal.
    */
-  ABSL_DEPRECATED("Slow, due to CSR compaction; prefer erase_edges().")
   bool erase_edge_between(int src, int dst);
 
   /**
@@ -918,14 +871,11 @@ public:
    * @param src The source node, interchangeable with \p dst.
    * @param dst The destination node, interchangeable with \p src.
    * @return Whether the edge is erased.
-   * @sa pop_edge(), erase_edge(), erase_edges()
+   * @sa erase_edge(), erase_edges()
    * @note Time complexity: same as erase_edge().
    * @note If \p src or \p dst does not belong to this graph, the behavior is
    *       undefined.
-   * @deprecated Slow, due to CSR compaction; prefer erase_edges() for bulk
-   *             removal.
    */
-  ABSL_DEPRECATED("Slow, due to CSR compaction; prefer erase_edges().")
   bool erase_edge_between(ConstNodeRef src, ConstNodeRef dst) {
     return erase_edge_between(src.id(), dst.id());
   }
@@ -942,7 +892,7 @@ public:
    *         edge removal), `new end id` will be equal to the size of the graph
    *         before this operation. Otherwise, `new end id` will be set to -1
    *         and erased edges will be marked as -1 in the mapping.
-   * @sa pop_edge(), erase_edge(), erase_edge_between()
+   * @sa erase_edge(), erase_edge_between()
    * @note Time complexity: \f$O(E)\f$ if no edges were removed, \f$O(V+E)\f$
    *       otherwise.
    * @note If any of the iterators in range `[`\p begin, \p end`)` is out of
@@ -969,7 +919,7 @@ public:
    *         trailing edge removal), `new end id` will be equal to the size of
    *         the graph before this operation. Otherwise, `new end id` will be
    *         set to -1 and erased edges will be marked as -1 in the mapping.
-   * @sa pop_edge(), erase_edge(), erase_edge_between()
+   * @sa erase_edge(), erase_edge_between()
    * @note Time complexity: same as
    *       erase_edges(const_edge_iterator, const_edge_iterator).
    * @note If any of the iterators in range `[`\p begin, \p end`)` is out of
@@ -994,7 +944,7 @@ public:
    *         trailing edge removal), `new end id` will be equal to the size of
    *         the graph before this operation. Otherwise, `new end id` will be
    *         set to -1 and erased edges will be marked as -1 in the mapping.
-   * @sa pop_edge(), erase_edge(), erase_edge_between()
+   * @sa erase_edge(), erase_edge_between()
    * @note Time complexity: same as
    *       erase_edges(const_edge_iterator, const_edge_iterator).
    * @note If any iterator in range `[`\p begin, \p end`)` references an invalid

--- a/include/nuri/core/graph/graph.h
+++ b/include/nuri/core/graph/graph.h
@@ -15,6 +15,8 @@
 #include <utility>
 #include <vector>
 
+#include <absl/algorithm/container.h>
+#include <absl/base/attributes.h>
 #include <absl/base/optimization.h>
 #include <absl/container/flat_hash_set.h>
 #include <absl/log/absl_check.h>
@@ -461,18 +463,18 @@ class Subgraph;
 template <class NT, class ET>
 class Graph {
 private:
-  struct StoredEdge {
-    int src;
-    int dst;
-    ET data;
-  };
-
   struct AdjEntry {
     int dst;
     int eid;
   };
 
 public:
+  struct StoredEdge {
+    int src;
+    int dst;
+    ET data;
+  };
+
   using node_data_type = NT;
   using edge_data_type = ET;
 
@@ -515,7 +517,7 @@ public:
    * @param num_nodes The number of nodes in the graph. All node data will be
    *        default-constructed.
    */
-  Graph(int num_nodes): adj_list_(num_nodes), nodes_(num_nodes) { }
+  Graph(int num_nodes): offsets_(num_nodes + 1), nodes_(num_nodes) { }
 
   /**
    * @brief Create a graph with \p num_nodes nodes, each initialized with
@@ -524,7 +526,7 @@ public:
    * @param data The data to copy-initialize each node with.
    */
   Graph(int num_nodes, const NT &data)
-      : adj_list_(num_nodes), nodes_(num_nodes, data) { }
+      : offsets_(num_nodes + 1), nodes_(num_nodes, data) { }
 
   bool empty() const {
     // GCOV_EXCL_START
@@ -547,14 +549,17 @@ public:
   }
   int num_edges() const { return static_cast<int>(edges_.size()); }
 
-  int degree(int id) const { return static_cast<int>(adj_list_[id].size()); }
+  int degree(int id) const { return offsets_[id + 1] - offsets_[id]; }
 
   void reserve(int num_nodes) {
     nodes_.reserve(num_nodes);
-    adj_list_.reserve(num_nodes);
+    offsets_.reserve(num_nodes + 1);
   }
 
-  void reserve_edges(int num_edges) { edges_.reserve(num_edges); }
+  void reserve_edges(int num_edges) {
+    edges_.reserve(num_edges);
+    adj_list_.reserve(num_edges * 2);
+  }
 
   /**
    * @brief Add a node to the graph.
@@ -565,7 +570,7 @@ public:
   int add_node(const NT &data) {
     int id = num_nodes();
     nodes_.push_back(data);
-    adj_list_.push_back({});
+    offsets_.push_back(offsets_[id]);
     return id;
   }
 
@@ -578,7 +583,7 @@ public:
   int add_node(NT &&data) noexcept {
     int id = num_nodes();
     nodes_.push_back(std::move(data));
-    adj_list_.push_back({});
+    offsets_.push_back(offsets_[id]);
     return id;
   }
 
@@ -594,7 +599,7 @@ public:
             internal::enable_if_compatible_iter_t<Iterator, NT> = 0>
   void add_nodes(Iterator begin, Iterator end) {
     nodes_.insert(nodes_.end(), begin, end);
-    adj_list_.resize(num_nodes());
+    offsets_.resize(num_nodes() + 1, offsets_.back());
   }
 
   /**
@@ -603,16 +608,18 @@ public:
    * @param dst The destination node id.
    * @param data The data to copy-construct the edge with.
    * @return The id of the newly added edge.
-   * @note Time complexity: \f$O(1)\f$ amortized.
+   * @note Time complexity: \f$O(N)\f$ amortized.
    * @note If \p src or \p dst is out of range, \p src equals \p dst, or an edge
    *       between \p src and \p dst already exists, the behavior is undefined.
+   * @deprecated Slow, due to CSR recompilation.
    */
+  ABSL_DEPRECATED("Slow, due to CSR recompilation.")
   int add_edge(int src, int dst, const ET &data) {
     ABSL_DCHECK_NE(src, dst) << "self-loop is not allowed";
 
     int eid = num_edges();
     edges_.push_back({ src, dst, data });
-    add_adjacency_entry(src, dst, eid);
+    publish_edges_from(eid);
     return eid;
   }
 
@@ -622,17 +629,36 @@ public:
    * @param dst The destination node id.
    * @param data The data to move-construct the edge with.
    * @return The id of the newly added edge.
-   * @note Time complexity: \f$O(1)\f$ amortized.
+   * @note Time complexity: \f$O(N)\f$ amortized.
    * @note If \p src or \p dst is out of range, \p src equals \p dst, or an edge
    *       between \p src and \p dst already exists, the behavior is undefined.
+   * @deprecated Slow, due to CSR recompilation.
    */
+  ABSL_DEPRECATED("Slow, due to CSR recompilation.")
   int add_edge(int src, int dst, ET &&data) noexcept {
     ABSL_DCHECK_NE(src, dst) << "self-loop is not allowed";
 
     int eid = num_edges();
     edges_.push_back({ src, dst, std::move(data) });
-    add_adjacency_entry(src, dst, eid);
+    publish_edges_from(eid);
     return eid;
+  }
+
+  /**
+   * @brief Add multiple edges to the graph.
+   * @tparam Iterator The type of the iterator for edges. Must be
+   *         dereferenceable to a value type implicitly convertible to
+   *         `StoredEdge`.
+   * @param begin The beginning of the range of edges to be added.
+   * @param end The end of the range of edges to be added.
+   * @note Time complexity: \f$O(E)\f$.
+   */
+  template <class Iterator,
+            internal::enable_if_compatible_iter_t<Iterator, StoredEdge> = 0>
+  void add_edges(Iterator begin, Iterator end) {
+    const int first = num_edges();
+    edges_.insert(edges_.end(), begin, end);
+    publish_edges_from(first);
   }
 
   NodeRef operator[](int id) { return node(id); }
@@ -648,6 +674,7 @@ public:
     nodes_.clear();
     edges_.clear();
     adj_list_.clear();
+    offsets_ = { 0 };
   }
 
   /**
@@ -820,8 +847,8 @@ public:
    */
   void clear_edges() {
     edges_.clear();
-    for (std::vector<AdjEntry> &adj: adj_list_)
-      adj.clear();
+    adj_list_.clear();
+    absl::c_fill(offsets_, 0);
   }
 
   /**
@@ -1055,8 +1082,12 @@ public:
     auto edges = other.edges();
     reserve_edges(num_edges() + edges.size());
 
-    for (auto edge: edges)
-      add_edge(edge.src().id() + offset, edge.dst().id() + offset, edge.data());
+    auto as_stored_edge = [offset](const auto &edge) {
+      return StoredEdge { edge.src().id() + offset, edge.dst().id() + offset,
+                          edge.data() };
+    };
+    add_edges(internal::make_transform_iterator(edges.begin(), as_stored_edge),
+              internal::make_transform_iterator(edges.end(), as_stored_edge));
   }
 
 private:
@@ -1106,34 +1137,65 @@ private:
   void erase_edges_common(std::vector<int> &edge_keep, int first_erased_id,
                           bool erase_trailing);
 
-  void add_adjacency_entry(int src, int dst, int eid) {
-    adj_list_[src].push_back({ dst, eid });
-    adj_list_[dst].push_back({ src, eid });
-  }
+  /**
+   * @brief Publish CSR adjacency entries for `edges_[first_eid .. end())`.
+   *
+   * Performs a delta-only update: only slices of nodes touched by the new
+   * edges are shifted, and only the new endpoints are materialized.
+   *
+   * Precondition: `offsets_` and `adj_list_` form a valid CSR view of
+   * `edges_[0 .. first_eid)`, and `offsets_.size() == nodes_.size() + 1`.
+   *
+   * @note Complexity: `O((V - v_min) + (E_total - first_eid))`, where
+   *       `v_min` is the smallest endpoint among the new edges. Degenerates
+   *       to `O(E_total - first_eid)` when every new edge's endpoints are
+   *       `>= num_nodes()` at the time of the last rebuild (the merge() hot
+   *       path).
+   */
+  void publish_edges_from(int first_eid);
 
   auto find_adjacency_entry(int src, int dst) {
-    return std::find_if(adj_list_[src].begin(), adj_list_[src].end(),
+    return std::find_if(adj_list_.begin() + offsets_[src],
+                        adj_list_.begin() + offsets_[src + 1],
                         [dst](const AdjEntry &adj) { return adj.dst == dst; });
   }
 
-  void erase_adjacency_entry(
-      int src, typename std::vector<AdjEntry>::const_iterator srcit, int dst,
-      typename std::vector<AdjEntry>::const_iterator dstit) {
-    adj_list_[src].erase(srcit);
-    adj_list_[dst].erase(dstit);
+  void erase_adjacency_entry(int src,
+                             typename std::vector<AdjEntry>::iterator srcit,
+                             int dst,
+                             typename std::vector<AdjEntry>::iterator dstit) {
+    if (src > dst) {
+      erase_adjacency_entry(dst, dstit, src, srcit);
+      return;
+    }
+
+    // Close the two gaps left by the removed entries via a pair of back-to-back
+    // left shifts on the flat buffer.
+    std::move(srcit + 1, dstit, srcit);
+    std::move(dstit + 1, adj_list_.end(), dstit - 1);
+    adj_list_.resize(adj_list_.size() - 2);
+
+    // Slices of nodes in (src, dst] shrink by 1 (one entry gone before them);
+    // slices of nodes > dst shrink by 2.
+    for (int v = src + 1; v <= dst; ++v)
+      --offsets_[v];
+    for (int v = dst + 1, n = static_cast<int>(offsets_.size()); v < n; ++v)
+      offsets_[v] -= 2;
   }
 
   AdjRef adjacent(int nid, int idx) {
-    const AdjEntry &adj = adj_list_[nid][idx];
+    const AdjEntry &adj = adj_list_[offsets_[nid] + idx];
     return { *this, nid, adj.dst, adj.eid };
   }
 
   ConstAdjRef adjacent(int nid, int idx) const {
-    const AdjEntry &adj = adj_list_[nid][idx];
+    const AdjEntry &adj = adj_list_[offsets_[nid] + idx];
     return { *this, nid, adj.dst, adj.eid };
   }
 
-  std::vector<std::vector<AdjEntry>> adj_list_;
+  std::vector<int> offsets_ = { 0 };
+  std::vector<AdjEntry> adj_list_;
+
   std::vector<NT> nodes_;
   std::vector<StoredEdge> edges_;
 };
@@ -1243,37 +1305,95 @@ Graph<NT, ET>::erase_nodes_common(std::vector<int> &node_keep,
     ABSL_DLOG(INFO) << "resizing adjacency & node list";
     // O(1) operations
     nodes_.resize(first_erased_id);
-    adj_list_.resize(nodes_.size());
+    offsets_.resize(first_erased_id + 1);
     return ret;
   }
 
-  // Erase unused nodes and adjacencies, O(V)
+  // Erase unused nodes, O(V)
   int i = 0;
   erase_if(nodes_,
            [&](const NT & /* unused */) { return node_keep[i++] == 0; });
-  i = 0;
-  erase_if(adj_list_, [&](const std::vector<AdjEntry> & /* unused */) {
-    return node_keep[i++] == 0;
-  });
 
   // Phase IV: update the node numbers in adjacencies and edges, O(V+E)
   mask_to_map(node_keep);
 
-  for (std::vector<AdjEntry> &adjs: adj_list_)
-    for (AdjEntry &adj: adjs)
-      adj.dst = node_keep[adj.dst];
+  for (int v = 0; v < static_cast<int>(node_keep.size()); ++v) {
+    int w = node_keep[v];
+    if (w < 0)
+      continue;
+    offsets_[w + 1] = offsets_[v + 1];
+  }
+  offsets_.resize(nodes_.size() + 1);
+
+  for (AdjEntry &adj: adj_list_)
+    adj.dst = node_keep[adj.dst];
 
   for (StoredEdge &edge: edges_) {
     edge.src = node_keep[edge.src];
     edge.dst = node_keep[edge.dst];
   }
 
+  return ret;
+}
+
+template <class NT, class ET>
+void Graph<NT, ET>::publish_edges_from(const int first_eid) {
+  const int total_edges = num_edges();
+  if (first_eid == total_edges)
+    return;
+
+  const int n = num_nodes();
+
+  // Phase 1: count per-node delta from just the new edges; track v_min.
+  std::vector<int> delta(n, 0);
+  int v_min = n;
+  for (int eid = first_eid; eid < total_edges; ++eid) {
+    const StoredEdge &e = edges_[eid];
+    ++delta[e.src];
+    ++delta[e.dst];
+    v_min = std::min({ v_min, e.src, e.dst });
+  }
+
+  // Phase 2: grow the flat buffer by the total number of new endpoints.
+  const int added = 2 * (total_edges - first_eid);
+  adj_list_.resize(adj_list_.size() + added);
+
+  // Phase 3: back-to-front shift of existing slices; update offsets_ in place.
+  //
+  // Invariant on entry to iteration `v`: `shift == sum(delta[v..n-1])`, which
+  // equals `shift_{v+1}` (= the offset-shift that was applied to node v+1's
+  // slice). Subtracting `delta[v]` yields `shift_v` for the current node.
+  int shift = added;
+  for (int i = n - 1; i > v_min; --i) {
+    const int old_end = offsets_[i + 1], old_start = offsets_[i],
+              old_deg = old_end - old_start;
+
+    offsets_[i + 1] = old_end + shift;
+    shift -= delta[i];
+    const int new_start = old_start + shift;
+    std::move_backward(adj_list_.begin() + old_start,
+                       adj_list_.begin() + old_end,
+                       adj_list_.begin() + new_start + old_deg);
+  }
+  offsets_[v_min + 1] += shift;
+
   // GCOV_EXCL_START
-  ABSL_DCHECK(num_nodes() == adj_list_.size())
-      << "node count mismatch: " << num_nodes() << " vs " << adj_list_.size();
+  ABSL_DCHECK_EQ(shift, delta[v_min])
+      << "shift mismatch: " << shift << " vs " << delta[v_min];
   // GCOV_EXCL_STOP
 
-  return ret;
+  // Phase 4: repurpose delta[] as per-node write cursors, each pointing at the
+  // start of its node's "gap" in the new layout:
+  //   cursor[v] = new_offsets[v+1] - delta[v] = new_offsets[v] + old_degree[v].
+  for (int v = v_min; v < n; ++v)
+    delta[v] = offsets_[v + 1] - delta[v];
+
+  // Phase 5: place new adjacency entries in eid order.
+  for (int eid = first_eid; eid < total_edges; ++eid) {
+    const StoredEdge &e = edges_[eid];
+    adj_list_[delta[e.src]++] = { e.dst, eid };
+    adj_list_[delta[e.dst]++] = { e.src, eid };
+  }
 }
 
 template <class NT, class ET>
@@ -1282,7 +1402,7 @@ bool Graph<NT, ET>::erase_edge_between(int src, int dst) {
     return erase_edge_between(dst, src);
 
   auto srcit = find_adjacency_entry(src, dst);
-  if (srcit == adj_list_[src].end())
+  if (srcit == adj_list_.begin() + offsets_[src + 1])
     return false;
 
   int eid = srcit->eid;
@@ -1297,17 +1417,15 @@ bool Graph<NT, ET>::erase_edge_between(int src, int dst) {
 
 template <class NT, class ET>
 void Graph<NT, ET>::erase_edge_common(int id) {
-  int orig_edges = num_edges();
+  const int orig_edges = num_edges();
   edges_.erase(edges_.begin() + id);
 
   if (id == orig_edges - 1)
     return;
 
-  for (std::vector<AdjEntry> &adjs: adj_list_) {
-    for (AdjEntry &adj: adjs) {
-      if (adj.eid > id)
-        --adj.eid;
-    }
+  for (AdjEntry &adj: adj_list_) {
+    if (adj.eid > id)
+      --adj.eid;
   }
 }
 
@@ -1379,10 +1497,19 @@ void Graph<NT, ET>::erase_edges_common(std::vector<int> &edge_keep,
   if (first_erased_id < 0 || first_erased_id >= num_edges())
     return;
 
-  // Phase II: erase unused adjacencies, O(V+E)
-  for (std::vector<AdjEntry> &adjs: adj_list_)
-    erase_if(adjs,
-             [&](const AdjEntry &adj) { return edge_keep[adj.eid] == 0; });
+  // Phase II: compact adj_list_ and rewrite offsets_ in place, O(V+E).
+  const int n = num_nodes();
+  int p = 0, old_end = 0;
+  for (int i = 0; i < n; ++i) {
+    const int old_start = old_end;
+    old_end = offsets_[i + 1];
+    for (int q = old_start; q < old_end; ++q) {
+      if (edge_keep[adj_list_[q].eid] != 0)
+        adj_list_[p++] = adj_list_[q];
+    }
+    offsets_[i + 1] = p;
+  }
+  adj_list_.resize(p);
 
   // Fast path 2: if only trailing edges are erased, no edge number needs to
   // be updated.
@@ -1399,12 +1526,11 @@ void Graph<NT, ET>::erase_edges_common(std::vector<int> &edge_keep,
     return edge_keep[i++] == 0;
   });
 
-  // Phase IV: update the edge numbers in adjacencies, O(V+E)
+  // Phase IV: update the edge numbers in adjacencies, O(E)
   mask_to_map(edge_keep);
 
-  for (std::vector<AdjEntry> &adjs: adj_list_)
-    for (AdjEntry &adj: adjs)
-      adj.eid = edge_keep[adj.eid];
+  for (AdjEntry &adj: adj_list_)
+    adj.eid = edge_keep[adj.eid];
 }
 
 namespace internal {

--- a/include/nuri/core/graph/graph.h
+++ b/include/nuri/core/graph/graph.h
@@ -593,13 +593,17 @@ public:
    *         a value type implicitly convertible to `NT`.
    * @param begin The beginning of the range of nodes to be added.
    * @param end The end of the range of nodes to be added.
+   * @return The first node id among the newly added nodes, or num_nodes() if no
+   *         nodes are added.
    * @note Time complexity: \f$O(N)\f$.
    */
   template <class Iterator,
             internal::enable_if_compatible_iter_t<Iterator, NT> = 0>
-  void add_nodes(Iterator begin, Iterator end) {
+  int add_nodes(Iterator begin, Iterator end) {
+    const int first = num_nodes();
     nodes_.insert(nodes_.end(), begin, end);
     offsets_.resize(num_nodes() + 1, offsets_.back());
+    return first;
   }
 
   /**
@@ -654,6 +658,8 @@ public:
    *         `StoredEdge`.
    * @param begin The beginning of the range of edges to be added.
    * @param end The end of the range of edges to be added.
+   * @return The first edge id among the newly added edges, or num_edges() if
+   *         no edges are added.
    * @note Time complexity: \f$O(V + E')\f$ in general, where \f$E'\f$ is the
    *       length of `[begin, end)`. Degenerates to \f$O(E')\f$ when every new
    *       edge's endpoints are among the nodes added since the last edge
@@ -661,10 +667,11 @@ public:
    */
   template <class Iterator,
             internal::enable_if_compatible_iter_t<Iterator, StoredEdge> = 0>
-  void add_edges(Iterator begin, Iterator end) {
+  int add_edges(Iterator begin, Iterator end) {
     const int first = num_edges();
     edges_.insert(edges_.end(), begin, end);
     publish_edges_from(first);
+    return first;
   }
 
   NodeRef operator[](int id) { return node(id); }

--- a/include/nuri/core/molecule.h
+++ b/include/nuri/core/molecule.h
@@ -20,6 +20,7 @@
 #include <absl/base/attributes.h>
 #include <absl/base/optimization.h>
 #include <absl/container/fixed_array.h>
+#include <absl/container/flat_hash_map.h>
 #include <absl/log/absl_check.h>
 #include <boost/container/flat_map.hpp>
 #include <Eigen/Dense>
@@ -1745,14 +1746,17 @@ private:
 /**
  * @brief A class to mutate a molecule.
  *
- * Atom and bond addition is directly applied to the molecule, but atom and bond
- * erasure is delayed until the `finalize()` method is called. This is because
- * the erasure of atoms might change the atom indices of the remaining atoms,
- * and might give unexpected results if the erasure is done before any other
- * mutations. The erasures will be applied in this order:
+ * Atom addition is directly applied to the molecule, but bond addition and
+ * atom/bond erasure are delayed until the `finalize()` method is called. This
+ * is because bulk bond addition is more efficient than individual bond
+ * addition, and atom erasure might change the atom indices of the remaining
+ * atoms, resulting in unexpected behavior if the mutation is not applied in the
+ * correct order. The `finalize()` method applies the mutations in the following
+ * order:
  *
- * 1. Bond erasures.
- * 2. Atom erasures.
+ * 1. Add registered bonds.
+ * 2. Erase marked bonds.
+ * 3. Erase marked atoms.
  *
  * If `finalize()` method is not explicitly called, the destructor will
  * automatically call it.
@@ -1773,8 +1777,7 @@ public:
    * @param mol The molecule to mutate.
    */
   MoleculeMutator(Molecule &mol)
-      : mol_(&mol), prev_num_atoms_(mol.num_atoms()),
-        prev_num_bonds_(mol.num_bonds()) { }
+      : mol_(&mol), prev_num_atoms_(mol.num_atoms()) { }
 
   MoleculeMutator() = delete;
   MoleculeMutator(const MoleculeMutator &) = delete;
@@ -1829,41 +1832,48 @@ public:
   void clear_atoms() noexcept;
 
   /**
-   * @brief Add a bond to the molecule.
+   * @brief Register a bond to be added to the molecule.
    * @param src Index of the source atom of the bond.
    * @param dst Index of the destination atom of the bond.
    * @param bond The data of the bond to add.
-   * @return A pair of (bond index, was added). If not added, the bond index is
-   *         the index of the existing bond (the data is not modified).
+   * @return A pair of (tentative bond index, will be added). The tentative bond
+   *         index is the index of the bond if it is added (before any erasure
+   *         is applied), or the index of the existing bond if it is not added.
+   *         The data of the existing bond is not modified.
    * @note The behavior is undefined if any of the atom indices is out of range,
    *       or if src == dst.
    */
-  std::pair<int, bool> add_bond(int src, int dst, const BondData &bond);
+  std::pair<int, bool> register_bond(int src, int dst, const BondData &bond);
 
   /**
-   * @brief Add a bond to the molecule.
+   * @brief Register a bond to be added to the molecule.
    * @param src Index of the source atom of the bond.
    * @param dst Index of the destination atom of the bond.
    * @param bond The data of the bond to add.
-   * @return A pair of (bond index, was added). If not added, the bond index is
-   *         the index of the existing bond (the data is not modified).
+   * @return A pair of (tentative bond index, will be added). The tentative bond
+   *         index is the index of the bond if it is added (before any erasure
+   *         is applied), or the index of the existing bond if it is not added.
+   *         The data of the existing bond is not modified.
    * @note The behavior is undefined if any of the atom indices is out of range,
    *       or if src == dst.
    */
-  std::pair<int, bool> add_bond(int src, int dst, BondData &&bond) noexcept;
+  std::pair<int, bool> register_bond(int src, int dst,
+                                     BondData &&bond) noexcept;
 
   /**
-   * @brief Add a bond to the molecule.
+   * @brief Register a bond to be added to the molecule.
    * @param src Index of the source atom of the bond.
    * @param dst Index of the destination atom of the bond.
    * @param bond The bond to copy the data from.
-   * @return A pair of (bond index, was added). If not added, the bond index is
-   *         the index of the existing bond (the data is not modified).
+   * @return A pair of (tentative bond index, will be added). The tentative bond
+   *         index is the index of the bond if it is added (before any erasure
+   *         is applied), or the index of the existing bond if it is not added.
+   *         The data of the existing bond is not modified.
    * @note The behavior is undefined if any of the atom indices is out of range,
    *       or if src == dst.
    */
-  std::pair<int, bool> add_bond(int src, int dst, Molecule::Bond bond) {
-    return add_bond(src, dst, bond.data());
+  std::pair<int, bool> register_bond(int src, int dst, Molecule::Bond bond) {
+    return register_bond(src, dst, bond.data());
   }
 
   /**
@@ -1904,14 +1914,9 @@ public:
   void clear() noexcept;
 
   /**
-   * @brief Cancel all pending atom and bond removals.
-   */
-  void discard_erasure() noexcept;
-
-  /**
    * @brief Finalize the mutation.
-   * @note The mutator internally calls discard_erasure() after applying
-   *       changes. Thus, successive calls to finalize() have no effect.
+   * @note The mutator internally calls discard() after applying changes. Thus,
+   *       successive calls to finalize() have no effect.
    * @sa Molecule::sanitize()
    *
    * This will effectively call Molecule::update_topology(), if any atoms or
@@ -1932,9 +1937,15 @@ public:
   // GCOV_EXCL_STOP
 
 private:
+  void discard_bonds() noexcept;
+
+  void discard() noexcept;
+
   Molecule *mol_;
   int prev_num_atoms_;
-  int prev_num_bonds_;
+
+  std::vector<Molecule::GraphType::StoredEdge> bond_registry_;
+  absl::flat_hash_map<int, std::vector<std::pair<int, int>>> delta_adj_;
 
   std::vector<int> erased_atoms_;
   std::vector<int> erased_bonds_;

--- a/python/include/nuri/python/core/core_module.h
+++ b/python/include/nuri/python/core/core_module.h
@@ -182,7 +182,7 @@ public:
 
   PyAtom add_atom(AtomData &&data);
 
-  PyBond add_bond(int src, int dst, BondData &&data);
+  int register_bond(int src, int dst, BondData &&data);
 
   void clear_atoms() {
     mut().clear_atoms();

--- a/python/src/nuri/core/molecule.cpp
+++ b/python/src/nuri/core/molecule.cpp
@@ -380,14 +380,15 @@ PyAtom PyMutator::add_atom(AtomData &&data) {
   return mol_->pyatom(idx);
 }
 
-PyBond PyMutator::add_bond(int src, int dst, BondData &&data) {
+int PyMutator::register_bond(int src, int dst, BondData &&data) {
   if (src == dst)
     throw py::value_error("source and destination atoms are the same");
 
-  auto [eid, ok] = mut().add_bond(src, dst, std::move(data));
+  auto [eid, ok] = mut().register_bond(src, dst, std::move(data));
   if (!ok)
     throw py::value_error("duplicate bond");
-  return mol_->pybond(eid);
+
+  return eid;
 }
 
 void PyBond::rotate(double angle, bool reverse, bool strict,
@@ -493,7 +494,7 @@ molecule:
 >>> with mol.mutator() as mut:  # doctest: +IGNORE_RESULT
 ...     src = mut.add_atom(6)
 ...     dst = mut.add_atom(6)
-...     mut.add_bond(src, dst)
+...     mut.register_bond(src, dst)
 >>> print(mol.num_atoms())
 2
 >>> print(mol.num_bonds())
@@ -545,7 +546,8 @@ We only document the differences from the original class. Refer to the
 :class:`BondData` class for common properties and methods.
 
 .. note:: Unlike the underlying data object, the bond cannot be created
-  directly. Use the :meth:`Mutator.add_bond` method to add a bond to a molecule.
+  directly. Use the :meth:`Mutator.register_bond` method to add a bond to a
+  molecule.
 )doc");
   py::class_<PyBondsWrapper> bonds(m, "_BondsWrapper");
 
@@ -1226,70 +1228,75 @@ context manager is exited.
 :param atom: The atom to erase.
 )doc")
       .def(
-          "add_bond",
+          "register_bond",
           [](PyMutator &self, int src, int dst, constants::BondOrder order) {
             std::tie(src, dst) = check_bond_ends(self.mol(), src, dst);
-            return self.add_bond(src, dst, BondData(get_or_throw_ord(order)));
+            return self.register_bond(src, dst,
+                                      BondData(get_or_throw_ord(order)));
           },
           py::arg("src"), py::arg("dst"),
-          py::arg("order") = constants::kSingleBond, kReturnsSubobject,
+          py::arg("order") = constants::kSingleBond,
           R"doc(
-Add a bond to the molecule.
+Register a bond to be added to the molecule. The bond is not actually added
+until the mutator context is exited.
 
 :param src: The index of the source atom.
 :param dst: The index of the destination atom.
 :param order: The order of the bond to add. Other properties of the bond are set
   to default. If not given, the bond is added with single bond order.
-:returns: The created bond.
+:returns: Index of the registered bond, after addition and before any deletions.
 )doc")
       .def(
-          "add_bond",
+          "register_bond",
           [](PyMutator &self, PyAtom &src, PyAtom &dst,
              constants::BondOrder order) {
             auto [sa, da] = check_bond_ends(self.mol(), src, dst);
-            return self.add_bond(sa.id(), da.id(),
-                                 BondData(get_or_throw_ord(order)));
+            return self.register_bond(sa.id(), da.id(),
+                                      BondData(get_or_throw_ord(order)));
           },
           py::arg("src"), py::arg("dst"),
-          py::arg("order") = constants::kSingleBond, kReturnsSubobject,
+          py::arg("order") = constants::kSingleBond,
           R"doc(
-Add a bond to the molecule.
+Register a bond to be added to the molecule. The bond is not actually added
+until the mutator context is exited.
 
 :param src: The source atom.
 :param dst: The destination atom.
 :param order: The order of the bond to add. Other properties of the bond are set
   to default. If not given, the bond is added with single bond order.
-:returns: The created bond.
+:returns: Index of the registered bond, after addition and before any deletions.
 )doc")
       .def(
-          "add_bond",
+          "register_bond",
           [](PyMutator &self, int src, int dst, const BondData &data) {
             std::tie(src, dst) = check_bond_ends(self.mol(), src, dst);
-            return self.add_bond(src, dst, BondData { data });
+            return self.register_bond(src, dst, BondData { data });
           },
-          py::arg("src"), py::arg("dst"), py::arg("data"), kReturnsSubobject,
+          py::arg("src"), py::arg("dst"), py::arg("data"),
           R"doc(
-Add a bond to the molecule.
+Register a bond to be added to the molecule. The bond is not actually added
+until the mutator context is exited.
 
 :param src: The index of the source atom.
 :param dst: The index of the destination atom.
 :param data: The data of the bond to add.
-:returns: The created bond.
+:returns: Index of the registered bond, after addition and before any deletions.
 )doc")
       .def(
-          "add_bond",
+          "register_bond",
           [](PyMutator &self, PyAtom &src, PyAtom &dst, const BondData &data) {
             auto [sa, da] = check_bond_ends(self.mol(), src, dst);
-            return self.add_bond(sa.id(), da.id(), BondData { data });
+            return self.register_bond(sa.id(), da.id(), BondData { data });
           },
-          py::arg("src"), py::arg("dst"), py::arg("data"), kReturnsSubobject,
+          py::arg("src"), py::arg("dst"), py::arg("data"),
           R"doc(
-Add a bond to the molecule.
+Register a bond to be added to the molecule. The bond is not actually added
+until the mutator context is exited.
 
 :param src: The source atom.
 :param dst: The destination atom.
 :param data: The data of the bond to add.
-:returns: The created bond.
+:returns: Index of the registered bond, after addition and before any deletions.
 )doc")
       .def(
           "mark_bond_erase",

--- a/python/test/algo/guess_test.py
+++ b/python/test/algo/guess_test.py
@@ -50,17 +50,17 @@ def arginine():
 @pytest.fixture()
 def arginine_bonds(arginine: Molecule):
     with arginine.mutator() as mut:
-        mut.add_bond(0, 1)
-        mut.add_bond(1, 2)
-        mut.add_bond(1, 4)
-        mut.add_bond(2, 3)
-        mut.add_bond(2, 11)
-        mut.add_bond(4, 5)
-        mut.add_bond(5, 6)
-        mut.add_bond(6, 7)
-        mut.add_bond(7, 8)
-        mut.add_bond(8, 9)
-        mut.add_bond(8, 10)
+        mut.register_bond(0, 1)
+        mut.register_bond(1, 2)
+        mut.register_bond(1, 4)
+        mut.register_bond(2, 3)
+        mut.register_bond(2, 11)
+        mut.register_bond(4, 5)
+        mut.register_bond(5, 6)
+        mut.register_bond(6, 7)
+        mut.register_bond(7, 8)
+        mut.register_bond(8, 9)
+        mut.register_bond(8, 10)
 
     return arginine
 

--- a/python/test/algo/rings_test.py
+++ b/python/test/algo/rings_test.py
@@ -16,11 +16,11 @@ def bcp():
         for _ in range(4):
             mut.add_atom(6)
 
-        mut.add_bond(0, 1)
-        mut.add_bond(0, 2)
-        mut.add_bond(1, 2)
-        mut.add_bond(1, 3)
-        mut.add_bond(2, 3)
+        mut.register_bond(0, 1)
+        mut.register_bond(0, 2)
+        mut.register_bond(1, 2)
+        mut.register_bond(1, 3)
+        mut.register_bond(2, 3)
 
     mol.sanitize()
     return mol
@@ -33,18 +33,18 @@ def cubane():
         for _ in range(8):
             mut.add_atom(6)
 
-        mut.add_bond(0, 1)
-        mut.add_bond(0, 3)
-        mut.add_bond(0, 5)
-        mut.add_bond(1, 2)
-        mut.add_bond(1, 6)
-        mut.add_bond(2, 7)
-        mut.add_bond(2, 3)
-        mut.add_bond(3, 4)
-        mut.add_bond(4, 5)
-        mut.add_bond(4, 7)
-        mut.add_bond(5, 6)
-        mut.add_bond(6, 7)
+        mut.register_bond(0, 1)
+        mut.register_bond(0, 3)
+        mut.register_bond(0, 5)
+        mut.register_bond(1, 2)
+        mut.register_bond(1, 6)
+        mut.register_bond(2, 7)
+        mut.register_bond(2, 3)
+        mut.register_bond(3, 4)
+        mut.register_bond(4, 5)
+        mut.register_bond(4, 7)
+        mut.register_bond(5, 6)
+        mut.register_bond(6, 7)
 
     mol.sanitize()
     return mol

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -30,16 +30,16 @@ def mol():
         n9 = mut.add_atom(7).update(formal_charge=-1)
         mut.add_atom(11).update(formal_charge=+1)
 
-        mut.add_bond(c0, n9)
-        mut.add_bond(c3, c2)
-        mut.add_bond(c3, c1, BondOrder.Double)
-        mut.add_bond(c1, c2)
-        mut.add_bond(c2, c0)
-        mut.add_bond(c2, hs[4])
-        mut.add_bond(n9, hs[5])
-        mut.add_bond(c3, hs[6])
-        mut.add_bond(c1, hs[7])
-        mut.add_bond(c0, hs[8])
+        mut.register_bond(c0, n9)
+        mut.register_bond(c3, c2)
+        mut.register_bond(c3, c1, BondOrder.Double)
+        mut.register_bond(c1, c2)
+        mut.register_bond(c2, c0)
+        mut.register_bond(c2, hs[4])
+        mut.register_bond(n9, hs[5])
+        mut.register_bond(c3, hs[6])
+        mut.register_bond(c1, hs[7])
+        mut.register_bond(c0, hs[8])
 
     return mol
 

--- a/python/test/core/molecule_test.py
+++ b/python/test/core/molecule_test.py
@@ -120,28 +120,25 @@ def test_add_bond():
     with mol.mutator() as mut:
         a1 = mut.add_atom(6)
         a2 = mut.add_atom(6)
-        bond = mut.add_bond(a1, a2)
-        assert bond.order == 1
-
-        bond_data = bond.copy_data()
+        bi = mut.register_bond(a1, a2)
 
         with pytest.raises(ValueError, match="same"):
-            mut.add_bond(0, 0)
+            mut.register_bond(0, 0)
 
         with pytest.raises(ValueError, match="duplicate bond"):
-            mut.add_bond(0, 1, BondOrder.Double)
+            mut.register_bond(0, 1, BondOrder.Double)
 
         with pytest.raises(IndexError):
-            mut.add_bond(0, 2, BondOrder.Double)
+            mut.register_bond(0, 2, BondOrder.Double)
 
         mut.add_atom(8)
 
         with pytest.raises(ValueError, match="invalid bond order"):
-            mut.add_bond(0, 2, BondOrder(1000))
+            mut.register_bond(0, 2, BondOrder(1000))
 
-        mut.add_bond(0, 2, BondOrder.Double)
+        mut.register_bond(0, 2, BondOrder.Double)
 
-    assert bond_data.order == 1
+    assert mol.bond(bi).order == 1
 
     assert len(mol) == 3
     assert mol.num_atoms() == 3
@@ -170,8 +167,8 @@ def test_add_bond():
         assert not mol.has_bond(a3.id, a4.id)
         assert not mol.has_bond(a3, a4)
 
-        mut.add_bond(a3, a4, BondData(BondOrder.Triple))
-        mut.add_bond(1, 3, BondData(BondOrder.Aromatic))
+        mut.register_bond(a3, a4, BondData(BondOrder.Triple))
+        mut.register_bond(1, 3, BondData(BondOrder.Aromatic))
 
 
 def test_add_conformer():
@@ -381,7 +378,7 @@ def test_add_other(mol: Molecule):
     with other.mutator() as mut:
         mut.add_atom(6)
         mut.add_atom(6)
-        mut.add_bond(0, 1)
+        mut.register_bond(0, 1)
 
     mol.add_from(other)
 

--- a/python/test/core/properties_test.py
+++ b/python/test/core/properties_test.py
@@ -23,7 +23,7 @@ def _get_mol():
     with m.mutator() as mut:
         mut.add_atom(6)
         mut.add_atom(6)
-        mut.add_bond(0, 1)
+        mut.register_bond(0, 1)
     return m
 
 

--- a/src/algo/guess/3d.cpp
+++ b/src/algo/guess/3d.cpp
@@ -94,7 +94,7 @@ namespace {
           continue;
 
         if (distsq[k] <= rcov_sum_sq(e, f, threshold))
-          mut.add_bond(i, j, {});
+          mut.register_bond(i, j, {});
       }
     }
   }
@@ -124,7 +124,7 @@ namespace {
           continue;
 
         if (distsq[i] <= rcov_sum_sq(e, f, threshold))
-          mut.add_bond(src.id(), dst.id(), {});
+          mut.register_bond(src.id(), dst.id(), {});
       }
     }
   }
@@ -174,6 +174,8 @@ namespace {
       guess_connectivity_small(mut, threshold, dist);
     else
       guess_connectivity_large(mut, threshold, oct);
+
+    mut.finalize();
 
     no_excess_bonds(mut.mol(), [&](Molecule::Atom atom, int max_neighbors) {
       remove_excess_bonds_max_n(mut, mut.mol()[atom.id()], max_neighbors, pos);

--- a/src/core/molecule/addh.cpp
+++ b/src/core/molecule/addh.cpp
@@ -918,7 +918,7 @@ bool Molecule::add_hydrogens(const bool update_confs, const bool optimize) {
     for (auto atom: *this) {
       for (int i = 0; i < atom.data().implicit_hydrogens(); ++i) {
         int h = mut.add_atom({ kPt[1], 0, 0, constants::kTerminal });
-        mut.add_bond(atom.id(), h, BondData(constants::kSingleBond));
+        mut.register_bond(atom.id(), h, BondData(constants::kSingleBond));
       }
     }
   }

--- a/src/core/molecule/mutator.cpp
+++ b/src/core/molecule/mutator.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include <absl/container/flat_hash_map.h>
 #include <absl/log/absl_check.h>
 #include <Eigen/Dense>
 

--- a/src/core/molecule/mutator.cpp
+++ b/src/core/molecule/mutator.cpp
@@ -4,6 +4,7 @@
 //
 
 #include <algorithm>
+#include <iterator>
 #include <numeric>
 #include <tuple>
 #include <utility>
@@ -18,54 +19,84 @@
 namespace nuri {
 void MoleculeMutator::clear_atoms() noexcept {
   mol().clear_atoms();
-  prev_num_atoms_ = prev_num_bonds_ = 0;
-  discard_erasure();
+  discard();
 }
 
 namespace {
-  template <class DT>
-  std::pair<int, bool> add_bond_impl(Molecule::GraphType &graph, int src,
-                                     int dst, DT &&bond) {
-    auto it = graph.find_edge(src, dst);
-    if (it != graph.edge_end())
-      return std::make_pair(it->id(), false);
+  int find_edge_both(
+      const Molecule::GraphType &graph,
+      absl::flat_hash_map<int, std::vector<std::pair<int, int>>> &delta_adj,
+      int src, int dst) {
+    if (auto it = graph.find_edge(src, dst); it != graph.edge_end())
+      return it->id();
 
-    int eid = graph.add_edge(src, dst, std::forward<DT>(bond));
+    auto it = delta_adj.find(src);
+    if (it == delta_adj.end())
+      return -1;
+
+    for (const auto &[d, e]: it->second) {
+      if (d == dst)
+        return e;
+    }
+
+    return -1;
+  }
+
+  template <class DT>
+  std::pair<int, bool> register_bond_impl(
+      const Molecule::GraphType &graph,
+      std::vector<Molecule::GraphType::StoredEdge> &new_bonds,
+      absl::flat_hash_map<int, std::vector<std::pair<int, int>>> &delta_adj,
+      int src, int dst, DT &&bond) {
+    if (int e = find_edge_both(graph, delta_adj, src, dst); e >= 0)
+      return std::make_pair(e, false);
+
+    int eid = graph.num_edges() + static_cast<int>(new_bonds.size());
+    new_bonds.push_back({ src, dst, std::forward<DT>(bond) });
+    delta_adj[src].emplace_back(dst, eid);
+    delta_adj[dst].emplace_back(src, eid);
     return std::make_pair(eid, true);
   }
 }  // namespace
 
-std::pair<int, bool> MoleculeMutator::add_bond(int src, int dst,
-                                               const BondData &bond) {
-  return add_bond_impl(mol().graph_, src, dst, bond);
+std::pair<int, bool> MoleculeMutator::register_bond(int src, int dst,
+                                                    const BondData &bond) {
+  return register_bond_impl(mol().graph_, bond_registry_, delta_adj_, src, dst,
+                            bond);
 }
 
-std::pair<int, bool> MoleculeMutator::add_bond(int src, int dst,
-                                               BondData &&bond) noexcept {
-  return add_bond_impl(mol().graph_, src, dst, std::move(bond));
+std::pair<int, bool> MoleculeMutator::register_bond(int src, int dst,
+                                                    BondData &&bond) noexcept {
+  return register_bond_impl(mol().graph_, bond_registry_, delta_adj_, src, dst,
+                            std::move(bond));
 }
 
 void MoleculeMutator::mark_bond_erase(int src, int dst) {
-  auto it = mol().find_bond(src, dst);
-  if (it != mol().bond_end())
-    erased_bonds_.push_back(it->id());
+  int e = find_edge_both(mol().graph_, delta_adj_, src, dst);
+  if (e >= 0)
+    erased_bonds_.push_back(e);
 }
 
 void MoleculeMutator::clear_bonds() noexcept {
   mol().clear_bonds();
-  prev_num_bonds_ = 0;
-  erased_bonds_.clear();
+  discard_bonds();
 }
 
 void MoleculeMutator::clear() noexcept {
   mol().clear();
-  prev_num_atoms_ = prev_num_bonds_ = 0;
-  discard_erasure();
+  discard();
 }
 
-void MoleculeMutator::discard_erasure() noexcept {
-  erased_atoms_.clear();
+void MoleculeMutator::discard_bonds() noexcept {
+  bond_registry_.clear();
+  delta_adj_.clear();
   erased_bonds_.clear();
+}
+
+void MoleculeMutator::discard() noexcept {
+  prev_num_atoms_ = mol().num_atoms();
+  erased_atoms_.clear();
+  discard_bonds();
 }
 
 namespace {
@@ -113,28 +144,32 @@ namespace {
 }  // namespace
 
 void MoleculeMutator::finalize() noexcept {
-  if (mol().num_atoms() == prev_num_atoms_
-      && mol().num_bonds() == prev_num_bonds_  //
-      && erased_atoms_.empty()                 //
+  if (mol().num_atoms() == prev_num_atoms_  //
+      && bond_registry_.empty()             //
+      && erased_atoms_.empty()              //
       && erased_bonds_.empty())
     return;
 
   Molecule::GraphType &g = mol().graph_;
   const int added_natom = mol().num_atoms();
-  const int added_nbond = mol().num_bonds();
   if (added_natom > prev_num_atoms_)
     for (Matrix3Xd &conf: mol().conformers_)
       conf.conservativeResize(Eigen::NoChange, added_natom);
 
   // As per the spec, the order is:
-  // 1. Erase bonds
+  // 1. Add bonds
+  g.add_edges(std::make_move_iterator(bond_registry_.begin()),
+              std::make_move_iterator(bond_registry_.end()));
+
+  // 2. Erase bonds
+  const int added_nbond = mol().num_bonds();
   std::pair<int, std::vector<int>> bond_info;
   bond_info = g.erase_edges(erased_bonds_.begin(), erased_bonds_.end());
   if (prepare_remap_idxs(added_nbond, bond_info.first, bond_info.second))
     for (Substructure &sub: mol().substructs_)
       sub.graph_.remap_edges(bond_info.second);
 
-  // 2. Erase atoms
+  // 3. Erase atoms
   std::pair<int, std::vector<int>> atom_info;
   std::tie(atom_info, bond_info) =
       g.erase_nodes(erased_atoms_.begin(), erased_atoms_.end());
@@ -153,9 +188,6 @@ void MoleculeMutator::finalize() noexcept {
   }
 
   mol().update_topology();
-
-  prev_num_atoms_ = mol().num_atoms();
-  prev_num_bonds_ = mol().num_bonds();
-  discard_erasure();
+  discard();
 }
 }  // namespace nuri

--- a/src/fmt/mmcif.cpp
+++ b/src/fmt/mmcif.cpp
@@ -614,7 +614,7 @@ void update_struct_conn(MoleculeMutator &mut,
     }
 
     auto [_, ok] =
-        mut.add_bond(sit->second, dit->second, BondData(conn.order()));
+        mut.register_bond(sit->second, dit->second, BondData(conn.order()));
     if (!ok)
       ABSL_LOG(WARNING) << "Duplicate bond between atoms " << sit->second
                         << " and " << dit->second;

--- a/src/fmt/mol2.cpp
+++ b/src/fmt/mol2.cpp
@@ -369,7 +369,7 @@ bool parse_bond_block(MoleculeMutator &mutator, Iter &it, const Iter end) {
     }
 
     auto [_, success] =
-        mutator.add_bond(mol_ids[0], mol_ids[1], std::get<1>(tokens));
+        mutator.register_bond(mol_ids[0], mol_ids[1], std::get<1>(tokens));
     if (!success) {
       ABSL_LOG(WARNING) << "Failed to add bond " << ids[0] << " -> " << ids[1]
                         << "; check mol2 file consistency";

--- a/src/fmt/pdb.cpp
+++ b/src/fmt/pdb.cpp
@@ -1975,7 +1975,8 @@ void read_connect_line(std::string_view line, const int src,
       continue;
     }
 
-    auto [_, added] = mut.add_bond(src, *dst, BondData(constants::kSingleBond));
+    auto [_, added] =
+        mut.register_bond(src, *dst, BondData(constants::kSingleBond));
     if (added)
       ABSL_VLOG(1) << "Added bond " << src << " -> " << *dst << " from CONECT";
   }

--- a/src/fmt/sdf.cpp
+++ b/src/fmt/sdf.cpp
@@ -306,8 +306,8 @@ ParseLineResult try_read_v2000_bond_line(MoleculeMutator &mut,
     return ParseLineResult::kError;
   }
 
-  auto [_, added] = mut.add_bond(static_cast<int>(src), static_cast<int>(dst),
-                                 std::move(data));
+  auto [_, added] = mut.register_bond(static_cast<int>(src),
+                                      static_cast<int>(dst), std::move(data));
   ABSL_LOG_IF(WARNING, !added) << "Duplicate bond " << src << " - " << dst;
 
   return ParseLineResult::kBond;
@@ -514,13 +514,9 @@ bool read_v2000(Molecule &mol, std::vector<Vector3d> &coords,
     }
   }
 
-  ABSL_LOG_IF(WARNING, mol.num_atoms() != metadata.natoms())
-      << "Inconsistent counts block and atoms block";
-
   // If result == kBond, bond already read in try_read_v2000_atom_line
   // Must increment first to avoid bond duplication
-  for (int i = mol.num_bonds();
-       status == ParseLineResult::kBond && ++it < end;) {
+  for (int i = 0; status == ParseLineResult::kBond && ++it < end;) {
     status = try_read_v2000_bond_line(mut, *it, i < metadata.nbonds());
 
     if (status == ParseLineResult::kError) {
@@ -535,9 +531,6 @@ bool read_v2000(Molecule &mol, std::vector<Vector3d> &coords,
 
     ++i;
   }
-
-  ABSL_LOG_IF(WARNING, mol.num_bonds() != metadata.nbonds())
-      << "Inconsistent counts block and bonds block";
 
   for (; status == ParseLineResult::kProp && it < end; ++it) {
     status = read_v2000_property_block(mol, *it);
@@ -673,8 +666,7 @@ bool try_read_v3000_header(HeaderReadResult &metadata, Iterator &it,
 }
 
 bool try_read_v3000_atom_block(MoleculeMutator &mut,
-                               std::vector<Vector3d> &coords,
-                               const HeaderReadResult metadata, Iterator &it,
+                               std::vector<Vector3d> &coords, Iterator &it,
                                const Iterator end, ContinuationReader &reader,
                                std::string &key) {
   if (++it >= end) {
@@ -748,14 +740,10 @@ bool try_read_v3000_atom_block(MoleculeMutator &mut,
     }
   }
 
-  ABSL_LOG_IF(WARNING, mut.mol().num_atoms() != metadata.natoms())
-      << "Inconsistent counts block and atoms block";
-
   return true;
 }
 
-bool try_read_v3000_bond_block(MoleculeMutator &mut,
-                               const HeaderReadResult metadata, Iterator &it,
+bool try_read_v3000_bond_block(MoleculeMutator &mut, Iterator &it,
                                const Iterator end, ContinuationReader &reader) {
   std::string_view line;
 
@@ -784,7 +772,7 @@ bool try_read_v3000_bond_block(MoleculeMutator &mut,
       return false;
     }
 
-    auto [_, added] = mut.add_bond(src, dst, std::move(data));
+    auto [_, added] = mut.register_bond(src, dst, std::move(data));
     ABSL_LOG_IF(WARNING, !added) << "Duplicate bond " << src << " - " << dst;
   }
 
@@ -801,14 +789,10 @@ bool try_read_v3000_bond_block(MoleculeMutator &mut,
     return false;
   }
 
-  ABSL_LOG_IF(WARNING, mut.mol().num_bonds() != metadata.nbonds())
-      << "Inconsistent counts block and bonds block";
-
   return true;
 }
 
-bool try_read_v3000_optionals(MoleculeMutator &mut,
-                              const HeaderReadResult metadata, Iterator &it,
+bool try_read_v3000_optionals(MoleculeMutator &mut, Iterator &it,
                               const Iterator end, ContinuationReader &reader) {
   std::stack<std::string, std::vector<std::string>> tokens;
   tokens.push("CTAB");
@@ -833,7 +817,7 @@ bool try_read_v3000_optionals(MoleculeMutator &mut,
         continue;
       }
 
-      if (!try_read_v3000_bond_block(mut, metadata, it, end, reader)) {
+      if (!try_read_v3000_bond_block(mut, it, end, reader)) {
         ABSL_LOG(ERROR) << "Failed to read V3000 bond block";
         return false;
       }
@@ -895,7 +879,7 @@ bool read_v3000(Molecule &mol, std::vector<Vector3d> &coords,
 
   auto mut = mol.mutator();
 
-  if (!try_read_v3000_atom_block(mut, coords, metadata, it, end, reader, key)) {
+  if (!try_read_v3000_atom_block(mut, coords, it, end, reader, key)) {
     ABSL_LOG(ERROR) << "Failed to read V3000 atom block";
     return false;
   }
@@ -906,7 +890,7 @@ bool read_v3000(Molecule &mol, std::vector<Vector3d> &coords,
     return true;
   }
 
-  if (!try_read_v3000_optionals(mut, metadata, it, end, reader)) {
+  if (!try_read_v3000_optionals(mut, it, end, reader)) {
     ABSL_LOG(ERROR) << "Failed to read V3000 optional blocks";
     return false;
   }
@@ -950,6 +934,11 @@ Molecule read_sdf(const std::vector<std::string> &sdf) {
     mol.clear();
     return mol;
   }
+
+  ABSL_LOG_IF(WARNING, mol.num_atoms() != metadata.natoms())
+      << "Inconsistent counts block and atoms block";
+  ABSL_LOG_IF(WARNING, mol.num_bonds() != metadata.nbonds())
+      << "Inconsistent counts block and bonds block";
 
   read_sdf_extra(mol, it, end);
 

--- a/src/fmt/smiles.cpp
+++ b/src/fmt/smiles.cpp
@@ -256,7 +256,7 @@ int add_bond(MoleculeMutator &mutator, ImplicitAromatics &aromatics,
   ABSL_DVLOG(3) << "Trying to add bond " << prev << " -> " << curr << ": "
                 << bond_data.order();
 
-  auto [eid, success] = mutator.add_bond(prev, curr, bond_data);
+  auto [eid, success] = mutator.register_bond(prev, curr, std::move(bond_data));
   if (implicit_aromatic)
     aromatics.push_back(eid);
   return success ? eid : -1;

--- a/src/tools/galign/prep.cpp
+++ b/src/tools/galign/prep.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <iterator>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -26,6 +27,7 @@ namespace nuri {
 namespace {
   auto parent_forest(const Molecule &mol) {
     Graph<std::vector<int>, std::pair<int, int>> forest;
+    std::vector<decltype(forest)::StoredEdge> fedges;
 
     internal::LinearQueue queue(
         std::vector<std::pair<int, int>>(mol.num_atoms()));
@@ -73,8 +75,9 @@ namespace {
             forest[curr_ti].data().push_back(next);
           } else {
             next_ti = forest.add_node({ next });
-            forest.add_edge(curr_ti, next_ti,
-                            { nei.src().id(), nei.dst().id() });
+            fedges.push_back({
+                curr_ti, next_ti, { nei.src().id(), nei.dst().id() }
+            });
           }
 
           if (nei.dst().degree() > 1)
@@ -82,6 +85,9 @@ namespace {
         }
       } while (!queue.empty());
     }
+
+    forest.add_edges(std::make_move_iterator(fedges.begin()),
+                     std::make_move_iterator(fedges.end()));
 
     return std::make_pair(forest, roots);
   }

--- a/test/algo/guess_test.cpp
+++ b/test/algo/guess_test.cpp
@@ -507,7 +507,7 @@ public:
   void add_bonds() {
     auto mut = mol_.mutator();
     for (auto [src, dst]: bonds_)
-      mut.add_bond(src, dst, {});
+      mut.register_bond(src, dst, {});
   }
 
   void verify_connectivity() const {
@@ -1139,10 +1139,10 @@ TEST(GuessFchargeOnly, Sulfonyl) {
     mut.add_atom(kPt[6]);
     mut.add_atom(kPt[7]);
 
-    mut.add_bond(0, 1, BondData(constants::kDoubleBond));
-    mut.add_bond(0, 2, BondData(constants::kDoubleBond));
-    mut.add_bond(0, 3, BondData(constants::kSingleBond));
-    mut.add_bond(0, 4, BondData(constants::kSingleBond));
+    mut.register_bond(0, 1, BondData(constants::kDoubleBond));
+    mut.register_bond(0, 2, BondData(constants::kDoubleBond));
+    mut.register_bond(0, 3, BondData(constants::kSingleBond));
+    mut.register_bond(0, 4, BondData(constants::kSingleBond));
   }
 
   mol.atom(3).data().set_implicit_hydrogens(3);
@@ -1166,21 +1166,26 @@ TEST(GuessFchargeOnly, Thiophene) {
     mut.add_atom(kPt[6]);
     mut.add_atom(kPt[6]);
 
-    mut.add_bond(0, 1,
-                 BondData(constants::kSingleBond)
-                     .add_flags(BondFlags::kAromatic | BondFlags::kConjugated));
-    mut.add_bond(1, 2,
-                 BondData(constants::kDoubleBond)
-                     .add_flags(BondFlags::kAromatic | BondFlags::kConjugated));
-    mut.add_bond(2, 3,
-                 BondData(constants::kSingleBond)
-                     .add_flags(BondFlags::kAromatic | BondFlags::kConjugated));
-    mut.add_bond(3, 4,
-                 BondData(constants::kDoubleBond)
-                     .add_flags(BondFlags::kAromatic | BondFlags::kConjugated));
-    mut.add_bond(4, 0,
-                 BondData(constants::kSingleBond)
-                     .add_flags(BondFlags::kAromatic | BondFlags::kConjugated));
+    mut.register_bond(0, 1,
+                      BondData(constants::kSingleBond)
+                          .add_flags(BondFlags::kAromatic
+                                     | BondFlags::kConjugated));
+    mut.register_bond(1, 2,
+                      BondData(constants::kDoubleBond)
+                          .add_flags(BondFlags::kAromatic
+                                     | BondFlags::kConjugated));
+    mut.register_bond(2, 3,
+                      BondData(constants::kSingleBond)
+                          .add_flags(BondFlags::kAromatic
+                                     | BondFlags::kConjugated));
+    mut.register_bond(3, 4,
+                      BondData(constants::kDoubleBond)
+                          .add_flags(BondFlags::kAromatic
+                                     | BondFlags::kConjugated));
+    mut.register_bond(4, 0,
+                      BondData(constants::kSingleBond)
+                          .add_flags(BondFlags::kAromatic
+                                     | BondFlags::kConjugated));
   }
 
   for (int i = 1; i < 4; ++i)
@@ -1210,21 +1215,26 @@ TEST(GuessFchargeOnly, ChargedThiophene) {
     mut.add_atom(kPt[6]);
     mut.add_atom(kPt[6]);
 
-    mut.add_bond(0, 1,
-                 BondData(constants::kSingleBond)
-                     .add_flags(BondFlags::kAromatic | BondFlags::kConjugated));
-    mut.add_bond(1, 2,
-                 BondData(constants::kDoubleBond)
-                     .add_flags(BondFlags::kAromatic | BondFlags::kConjugated));
-    mut.add_bond(2, 3,
-                 BondData(constants::kSingleBond)
-                     .add_flags(BondFlags::kAromatic | BondFlags::kConjugated));
-    mut.add_bond(3, 4,
-                 BondData(constants::kDoubleBond)
-                     .add_flags(BondFlags::kAromatic | BondFlags::kConjugated));
-    mut.add_bond(4, 0,
-                 BondData(constants::kSingleBond)
-                     .add_flags(BondFlags::kAromatic | BondFlags::kConjugated));
+    mut.register_bond(0, 1,
+                      BondData(constants::kSingleBond)
+                          .add_flags(BondFlags::kAromatic
+                                     | BondFlags::kConjugated));
+    mut.register_bond(1, 2,
+                      BondData(constants::kDoubleBond)
+                          .add_flags(BondFlags::kAromatic
+                                     | BondFlags::kConjugated));
+    mut.register_bond(2, 3,
+                      BondData(constants::kSingleBond)
+                          .add_flags(BondFlags::kAromatic
+                                     | BondFlags::kConjugated));
+    mut.register_bond(3, 4,
+                      BondData(constants::kDoubleBond)
+                          .add_flags(BondFlags::kAromatic
+                                     | BondFlags::kConjugated));
+    mut.register_bond(4, 0,
+                      BondData(constants::kSingleBond)
+                          .add_flags(BondFlags::kAromatic
+                                     | BondFlags::kConjugated));
   }
 
   for (auto atom: mol)

--- a/test/algo/rings_test.cpp
+++ b/test/algo/rings_test.cpp
@@ -40,16 +40,16 @@ protected:
       }
 
       // 0-5-0 is a ring, 4-8-4 is a ring
-      m.add_bond(0, 1, BondData(kAromaticBond));
-      m.add_bond(0, 5, BondData(kAromaticBond));
-      m.add_bond(1, 2, BondData(kAromaticBond));
-      m.add_bond(2, 3, BondData(kAromaticBond));
-      m.add_bond(3, 4, BondData(kAromaticBond));
-      m.add_bond(4, 5, BondData(kAromaticBond));
-      m.add_bond(4, 8, BondData(kAromaticBond));
-      m.add_bond(5, 6, BondData(kAromaticBond));
-      m.add_bond(6, 7, BondData(kAromaticBond));
-      m.add_bond(7, 8, BondData(kAromaticBond));
+      m.register_bond(0, 1, BondData(kAromaticBond));
+      m.register_bond(0, 5, BondData(kAromaticBond));
+      m.register_bond(1, 2, BondData(kAromaticBond));
+      m.register_bond(2, 3, BondData(kAromaticBond));
+      m.register_bond(3, 4, BondData(kAromaticBond));
+      m.register_bond(4, 5, BondData(kAromaticBond));
+      m.register_bond(4, 8, BondData(kAromaticBond));
+      m.register_bond(5, 6, BondData(kAromaticBond));
+      m.register_bond(6, 7, BondData(kAromaticBond));
+      m.register_bond(7, 8, BondData(kAromaticBond));
     }
   }
 
@@ -181,28 +181,30 @@ TEST_F(IndoleRingTest, MaxFiveRingSets) {
 class CubaneRingTest: public ::testing::Test {
 protected:
   static void SetUpTestSuite() {
-    auto m = mol_.mutator();
-    for (int i = 0; i < 8; ++i) {
-      m.add_atom(kPt[6]);
-    }
-    for (int i = 0; i < 8; ++i) {
-      mol_.atom(i).data().set_implicit_hydrogens(1);
-    }
+    {
+      auto m = mol_.mutator();
+      for (int i = 0; i < 8; ++i) {
+        m.add_atom(kPt[6]);
+      }
+      for (int i = 0; i < 8; ++i) {
+        mol_.atom(i).data().set_implicit_hydrogens(1);
+      }
 
-    // Six relevant rings:
-    // 0-1-2-3-0, 0-3-4-5-0, 0-1-6-5-0, 1-2-7-6-1, 2-3-4-7-2, 4-5-6-7-4
-    m.add_bond(0, 1, BondData(kSingleBond));
-    m.add_bond(0, 3, BondData(kSingleBond));
-    m.add_bond(0, 5, BondData(kSingleBond));
-    m.add_bond(1, 2, BondData(kSingleBond));
-    m.add_bond(1, 6, BondData(kSingleBond));
-    m.add_bond(2, 3, BondData(kSingleBond));
-    m.add_bond(2, 7, BondData(kSingleBond));
-    m.add_bond(3, 4, BondData(kSingleBond));
-    m.add_bond(4, 5, BondData(kSingleBond));
-    m.add_bond(4, 7, BondData(kSingleBond));
-    m.add_bond(5, 6, BondData(kSingleBond));
-    m.add_bond(6, 7, BondData(kSingleBond));
+      // Six relevant rings:
+      // 0-1-2-3-0, 0-3-4-5-0, 0-1-6-5-0, 1-2-7-6-1, 2-3-4-7-2, 4-5-6-7-4
+      m.register_bond(0, 1, BondData(kSingleBond));
+      m.register_bond(0, 3, BondData(kSingleBond));
+      m.register_bond(0, 5, BondData(kSingleBond));
+      m.register_bond(1, 2, BondData(kSingleBond));
+      m.register_bond(1, 6, BondData(kSingleBond));
+      m.register_bond(2, 3, BondData(kSingleBond));
+      m.register_bond(2, 7, BondData(kSingleBond));
+      m.register_bond(3, 4, BondData(kSingleBond));
+      m.register_bond(4, 5, BondData(kSingleBond));
+      m.register_bond(4, 7, BondData(kSingleBond));
+      m.register_bond(5, 6, BondData(kSingleBond));
+      m.register_bond(6, 7, BondData(kSingleBond));
+    }
 
     sub_.update_atoms({ 1, 2, 4, 5, 6, 7 });
   }

--- a/test/core/graph/adaptor_test.cpp
+++ b/test/core/graph/adaptor_test.cpp
@@ -26,27 +26,30 @@ Graph c5_petersen_graph() {
   for (int i = 0; i < 15; ++i)
     g.add_node(i);
 
-  g.add_edge(0, 1, 0);
-  g.add_edge(1, 2, 1);
-  g.add_edge(2, 3, 2);
-  g.add_edge(3, 4, 3);
-  g.add_edge(4, 0, 4);
-
-  g.add_edge(5, 6, 5);
-  g.add_edge(6, 7, 6);
-  g.add_edge(7, 8, 7);
-  g.add_edge(8, 9, 8);
-  g.add_edge(9, 5, 9);
-  g.add_edge(5, 10, 10);
-  g.add_edge(6, 11, 11);
-  g.add_edge(7, 12, 12);
-  g.add_edge(8, 13, 13);
-  g.add_edge(9, 14, 14);
-  g.add_edge(10, 13, 15);
-  g.add_edge(10, 12, 16);
-  g.add_edge(14, 11, 17);
-  g.add_edge(14, 12, 18);
-  g.add_edge(11, 13, 19);
+  Graph::StoredEdge edges[] = {
+    {  0,  1,  0 },
+    {  1,  2,  1 },
+    {  2,  3,  2 },
+    {  3,  4,  3 },
+    {  4,  0,  4 },
+    //
+    {  5,  6,  5 },
+    {  6,  7,  6 },
+    {  7,  8,  7 },
+    {  8,  9,  8 },
+    {  9,  5,  9 },
+    {  5, 10, 10 },
+    {  6, 11, 11 },
+    {  7, 12, 12 },
+    {  8, 13, 13 },
+    {  9, 14, 14 },
+    { 10, 13, 15 },
+    { 10, 12, 16 },
+    { 14, 11, 17 },
+    { 14, 12, 18 },
+    { 11, 13, 19 },
+  };
+  g.add_edges(std::begin(edges), std::end(edges));
 
   return g;
 }

--- a/test/core/graph/graph_test.cpp
+++ b/test/core/graph/graph_test.cpp
@@ -81,6 +81,9 @@ class BasicGraphTest: public testing::Test { };
 
 TYPED_TEST_SUITE(BasicGraphTest, Implementations);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 TYPED_TEST(BasicGraphTest, CreationTest) {
   using Graph = nuri::Graph<TypeParam, TypeParam>;
 
@@ -264,6 +267,8 @@ TYPED_TEST(BasicGraphTest, AddEdgeTest) {
                 "const edge iterator should not be assignable");
 }
 
+#pragma GCC diagnostic pop
+
 template <class T>
 class AdvancedGraphTest: public testing::Test {
 public:
@@ -279,19 +284,22 @@ protected:
       graph_.add_node({ i });
     }
 
-    graph_.add_edge(0, 1, { 100 });
-    graph_.add_edge(0, 2, { 101 });
-    graph_.add_edge(5, 0, { 102 });
-    graph_.add_edge(6, 0, { 103 });
-
-    graph_.add_edge(1, 2, { 104 });
-    graph_.add_edge(7, 1, { 105 });
-    graph_.add_edge(8, 1, { 106 });
-
-    graph_.add_edge(2, 3, { 107 });
-    graph_.add_edge(9, 2, { 108 });
-
-    graph_.add_edge(3, 4, { 109 });
+    typename Graph::StoredEdge edges[] = {
+      { 0, 1, { 100 } },
+      { 0, 2, { 101 } },
+      { 5, 0, { 102 } },
+      { 6, 0, { 103 } },
+      //
+      { 1, 2, { 104 } },
+      { 7, 1, { 105 } },
+      { 8, 1, { 106 } },
+      //
+      { 2, 3, { 107 } },
+      { 9, 2, { 108 } },
+      //
+      { 3, 4, { 109 } },
+    };
+    graph_.add_edges(std::begin(edges), std::end(edges));
   }
 
   /**
@@ -548,35 +556,6 @@ TYPED_TEST(AdvancedGraphTest, AdjIteratorTest) {
   ASSERT_EQ(it1[2].edge_data(), -1);
 }
 
-TYPED_TEST(AdvancedGraphTest, PopNodeTest) {
-  using Graph = nuri::Graph<TypeParam, TypeParam>;
-  Graph &graph = this->graph_;
-
-  auto data = graph.pop_node(0);
-  ASSERT_EQ(data, 0);
-  ASSERT_EQ(graph.num_nodes(), 10);
-  ASSERT_EQ(graph.num_edges(), 6);
-  for (int i = 0; i < 10; ++i) {
-    ASSERT_EQ(graph.node(i).id(), i);
-    ASSERT_EQ(graph.node(i).data(), i + 1);
-  }
-
-  ASSERT_NE(graph.find_adjacent(0, 1), graph.adj_end(0));
-  ASSERT_NE(graph.find_adjacent(0, 6), graph.adj_end(0));
-  ASSERT_NE(graph.find_adjacent(0, 7), graph.adj_end(0));
-  ASSERT_NE(graph.find_adjacent(1, 2), graph.adj_end(1));
-  ASSERT_NE(graph.find_adjacent(1, 8), graph.adj_end(1));
-  ASSERT_NE(graph.find_adjacent(2, 3), graph.adj_end(2));
-
-  data = graph.pop_node(1);
-  ASSERT_EQ(data, 2);
-  ASSERT_EQ(graph.num_nodes(), 9);
-  ASSERT_EQ(graph.num_edges(), 3);
-  ASSERT_NE(graph.find_adjacent(0, 5), graph.adj_end(0));
-  ASSERT_NE(graph.find_adjacent(0, 6), graph.adj_end(0));
-  ASSERT_NE(graph.find_adjacent(1, 2), graph.adj_end(1));
-}
-
 TYPED_TEST(AdvancedGraphTest, EraseNoNodeTest) {
   using Graph = nuri::Graph<TypeParam, TypeParam>;
   Graph &graph = this->graph_;
@@ -687,23 +666,6 @@ TYPED_TEST(AdvancedGraphTest, EraseMixedNodesTest) {
   ASSERT_EQ(graph.find_adjacent(0, 3)->edge_data(), 105);
 }
 
-TYPED_TEST(AdvancedGraphTest, PopEdgeTest) {
-  using Graph = nuri::Graph<TypeParam, TypeParam>;
-  Graph &graph = this->graph_;
-
-  auto data = graph.pop_edge(0);
-  ASSERT_EQ(data, 100);
-  ASSERT_EQ(graph.num_edges(), 9);
-  ASSERT_EQ(graph.find_adjacent(0, 1), graph.adj_end(0));
-
-  data = graph.pop_edge(1);
-  ASSERT_EQ(data, 102);
-  ASSERT_EQ(graph.num_edges(), 8);
-  ASSERT_EQ(graph.find_adjacent(0, 5), graph.adj_end(0));
-
-  ASSERT_EQ(graph.num_nodes(), 11);
-}
-
 TYPED_TEST(AdvancedGraphTest, EraseEdgeTest) {
   using Graph = nuri::Graph<TypeParam, TypeParam>;
   Graph &graph = this->graph_;
@@ -756,11 +718,14 @@ TYPED_TEST(AdvancedGraphTest, EraseMixedEdgesTest) {
   ASSERT_EQ(graph.find_adjacent(3, 4)->edge_data(), 109);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 TYPED_TEST(AdvancedGraphTest, EraseAddTest) {
   using Graph = nuri::Graph<TypeParam, TypeParam>;
   Graph &graph = this->graph_;
 
-  graph.pop_node(1);
+  graph.erase_nodes(graph.begin() + 1, graph.begin() + 2);
   graph.add_node({ 11 });
   ASSERT_EQ(graph.num_nodes(), 11);
 
@@ -806,6 +771,8 @@ TYPED_TEST(AdvancedGraphTest, MergeOther) {
   EXPECT_EQ(graph.node(12).data(), 12);
   EXPECT_EQ(graph.find_edge(11, 12)->data(), 1112);
 }
+
+#pragma GCC diagnostic pop
 }  // namespace
 
 // Explicit instantiation of few template classes for coverage report.

--- a/test/core/graph/subgraph_test.cpp
+++ b/test/core/graph/subgraph_test.cpp
@@ -275,16 +275,19 @@ protected:
       graph_.add_node({ i });
     }
 
-    graph_.add_edge(3, 1, { 100 });
-    graph_.add_edge(3, 2, { 101 });
-    graph_.add_edge(5, 3, { 102 });
-    graph_.add_edge(6, 3, { 103 });
-    graph_.add_edge(1, 2, { 104 });
-    graph_.add_edge(7, 1, { 105 });
-    graph_.add_edge(8, 1, { 106 });
-    graph_.add_edge(2, 0, { 107 });
-    graph_.add_edge(9, 2, { 108 });
-    graph_.add_edge(0, 4, { 109 });
+    Graph::StoredEdge edges[] = {
+      { 3, 1, 100 },
+      { 3, 2, 101 },
+      { 5, 3, 102 },
+      { 6, 3, 103 },
+      { 1, 2, 104 },
+      { 7, 1, 105 },
+      { 8, 1, 106 },
+      { 2, 0, 107 },
+      { 9, 2, 108 },
+      { 0, 4, 109 },
+    };
+    graph_.add_edges(std::begin(edges), std::end(edges));
 
     sg_ = subgraph_from_nodes(graph_, { 3, 10, 1, 2 });
     ASSERT_EQ(sg_.size(), 4);
@@ -482,6 +485,7 @@ TEST_F(AdvancedSubgraphTest, UpdateEdges) {
 }
 
 TEST_F(AdvancedSubgraphTest, RefreshEdges) {
+  // NOLINTNEXTLINE(*-deprecated-declarations)
   graph_.add_edge(2, 10, { 110 });
 
   sg_.refresh_edges();

--- a/test/core/graph/subgraph_test.cpp
+++ b/test/core/graph/subgraph_test.cpp
@@ -484,8 +484,10 @@ TEST_F(AdvancedSubgraphTest, UpdateEdges) {
   EXPECT_TRUE(sg_.contains_node(8));
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 TEST_F(AdvancedSubgraphTest, RefreshEdges) {
-  // NOLINTNEXTLINE(*-deprecated-declarations)
   graph_.add_edge(2, 10, { 110 });
 
   sg_.refresh_edges();
@@ -493,6 +495,8 @@ TEST_F(AdvancedSubgraphTest, RefreshEdges) {
   EXPECT_EQ(sg_.num_edges(), 4);
   EXPECT_TRUE(sg_.contains_edge(10));
 }
+
+#pragma GCC diagnostic pop
 
 TEST_F(AdvancedSubgraphTest, AddEdges) {
   sg_.add_edge(2);

--- a/test/core/graph/vf2pp_test.cpp
+++ b/test/core/graph/vf2pp_test.cpp
@@ -27,6 +27,7 @@ int lid(const GT &g, int i) {
 }
 
 auto lemon_add_edge(GT &g, int src, int dst, int data) {
+  // NOLINTNEXTLINE(*-deprecated-declarations)
   return g.add_edge(lid(g, src), lid(g, dst), data);
 }
 

--- a/test/core/graph/vf2pp_test.cpp
+++ b/test/core/graph/vf2pp_test.cpp
@@ -26,10 +26,14 @@ int lid(const GT &g, int i) {
   return g[i].data();
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 auto lemon_add_edge(GT &g, int src, int dst, int data) {
-  // NOLINTNEXTLINE(*-deprecated-declarations)
   return g.add_edge(lid(g, src), lid(g, dst), data);
 }
+
+#pragma GCC diagnostic pop
 
 GT lemon_c_n(int n) {
   GT g;

--- a/test/core/molecule/addh_test.cpp
+++ b/test/core/molecule/addh_test.cpp
@@ -223,7 +223,7 @@ TEST(AddHSp, Fixed1) {
     auto mut = mol.mutator();
     mut.add_atom({ kPt[6], 1, 0, Hyb::kSP });
     mut.add_atom({ kPt[7], 0, 0, Hyb::kTerminal });
-    mut.add_bond(0, 1, BondData(Ord::kTripleBond));
+    mut.register_bond(0, 1, BondData(Ord::kTripleBond));
 
     mol.confs().emplace_back(Matrix3Xd::Zero(3, 2)).col(1) =
         Vector3d::Random().normalized() * cn_bl;
@@ -252,7 +252,7 @@ TEST(AddHSp2, Fixed1) {
     auto mut = mol.mutator();
     mut.add_atom({ kPt[5], 2, 0, Hyb::kSP2 });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
 
     mol.confs().emplace_back(Matrix3Xd::Zero(3, 2)).col(1) =
         Vector3d::Random().normalized()
@@ -268,7 +268,7 @@ TEST(AddHSp2, Fixed1E1) {
     auto mut = mol.mutator();
     mut.add_atom({ kPt[6], 1, 0, Hyb::kSP2 });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
 
     mol.confs().emplace_back(Matrix3Xd::Zero(3, 2)).col(1) =
         Vector3d::Random().normalized()
@@ -285,8 +285,8 @@ TEST(AddHSp2, Fixed2) {
     mut.add_atom({ kPt[5], 1, 0, Hyb::kSP2 });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 2, BondData(Ord::kSingleBond));
   }
 
   ASSERT_TRUE(generate_coords(mol));
@@ -347,7 +347,7 @@ TEST(AddHSp3, Fixed1E12) {
     mut.add_atom({ kPt[7], 2, 0, Hyb::kSP3 });
     mut.add_atom({ kPt[8], 1, 0, Hyb::kSP3 });
 
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
   }
 
   mol.confs().emplace_back(Matrix3Xd::Zero(3, 2)).col(1) =
@@ -365,8 +365,8 @@ TEST(AddHSp3, Fixed2E1) {
     mut.add_atom({ kPt[6], 3, 0, Hyb::kSP3 });
     mut.add_atom({ kPt[6], 3, 0, Hyb::kSP3 });
 
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 2, BondData(Ord::kSingleBond));
   }
 
   ASSERT_TRUE(generate_coords(mol));
@@ -395,19 +395,19 @@ TEST(AddHSp3d, Fixed1E0123) {
     auto mut = mol.mutator();
     mut.add_atom({ kPt[15], 4, 0, Hyb::kSP3D });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
 
     mut.add_atom({ kPt[15], 3, 0, Hyb::kSP3D });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
-    mut.add_bond(2, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(2, 3, BondData(Ord::kSingleBond));
 
     mut.add_atom({ kPt[15], 2, 0, Hyb::kSP3D });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
-    mut.add_bond(4, 5, BondData(Ord::kSingleBond));
+    mut.register_bond(4, 5, BondData(Ord::kSingleBond));
 
     mut.add_atom({ kPt[15], 1, 0, Hyb::kSP3D });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
-    mut.add_bond(6, 7, BondData(Ord::kSingleBond));
+    mut.register_bond(6, 7, BondData(Ord::kSingleBond));
   }
 
   double bl = kPt[15].covalent_radius() + kPt[9].covalent_radius();
@@ -426,10 +426,10 @@ TEST(AddHSp3d, Fixed2AxE012) {
     mut.add_atom({ kPt[15], 1, 0, Hyb::kSP3D });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
 
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
-    mut.add_bond(1, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(2, 3, BondData(Ord::kSingleBond));
-    mut.add_bond(3, 4, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(1, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(2, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(3, 4, BondData(Ord::kSingleBond));
   }
 
   double ble = kPt[15].covalent_radius() + kPt[9].covalent_radius(),
@@ -450,10 +450,10 @@ TEST(AddHSp3d, Fixed2AxEqE012) {
     mut.add_atom({ kPt[17], 1, 0, Hyb::kSP3D });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
 
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
-    mut.add_bond(1, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(2, 3, BondData(Ord::kSingleBond));
-    mut.add_bond(3, 4, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(1, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(2, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(3, 4, BondData(Ord::kSingleBond));
   }
 
   mol.confs().emplace_back(3, 5).transpose() << 3.6415, 3.7358, -0.0126, 1.9718,
@@ -473,10 +473,10 @@ TEST(AddHSp3d, Fixed2EqE012) {
     mut.add_atom({ kPt[17], 1, 0, Hyb::kSP3D });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
 
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
-    mut.add_bond(1, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(2, 3, BondData(Ord::kSingleBond));
-    mut.add_bond(3, 4, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(1, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(2, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(3, 4, BondData(Ord::kSingleBond));
   }
 
   Array4d bls { kPt[9].covalent_radius() + kPt[15].covalent_radius(),
@@ -506,11 +506,11 @@ TEST(AddHSp3d, Fixed3Eq3E01) {
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
 
-    mut.add_bond(0, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(1, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(2, 3, BondData(Ord::kSingleBond));
-    mut.add_bond(3, 4, BondData(Ord::kSingleBond));
-    mut.add_bond(3, 5, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(1, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(2, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(3, 4, BondData(Ord::kSingleBond));
+    mut.register_bond(3, 5, BondData(Ord::kSingleBond));
   }
 
   Array3d bls { kPt[9].covalent_radius() + kPt[15].covalent_radius(),
@@ -542,11 +542,11 @@ TEST(AddHSp3d, Fixed3Eq2E01) {
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
 
-    mut.add_bond(0, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(1, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(2, 3, BondData(Ord::kSingleBond));
-    mut.add_bond(3, 4, BondData(Ord::kSingleBond));
-    mut.add_bond(3, 5, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(1, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(2, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(3, 4, BondData(Ord::kSingleBond));
+    mut.register_bond(3, 5, BondData(Ord::kSingleBond));
   }
 
   mol.confs().emplace_back(3, 6).transpose() << -2.5352, 1.5770, -0.9663,
@@ -567,11 +567,11 @@ TEST(AddHSp3d, Fixed3Eq1E01) {
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
 
-    mut.add_bond(0, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(1, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(2, 3, BondData(Ord::kSingleBond));
-    mut.add_bond(3, 4, BondData(Ord::kSingleBond));
-    mut.add_bond(3, 5, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(1, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(2, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(3, 4, BondData(Ord::kSingleBond));
+    mut.register_bond(3, 5, BondData(Ord::kSingleBond));
   }
 
   Array3d bls { kPt[9].covalent_radius() + kPt[15].covalent_radius(),
@@ -600,10 +600,10 @@ TEST(AddHSp3d, Fixed4Ax) {
     mut.add_atom({ kPt[17], 0, 0, Hyb::kTerminal });
     mut.add_atom({ kPt[17], 0, 0, Hyb::kTerminal });
 
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 3, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 4, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 4, BondData(Ord::kSingleBond));
   }
 
   mol.confs().emplace_back(Matrix3Xd::Zero(3, 5)).transpose() << -0.0261,
@@ -623,10 +623,10 @@ TEST(AddHSp3d, Fixed4Eq) {
     mut.add_atom({ kPt[17], 0, 0, Hyb::kTerminal });
     mut.add_atom({ kPt[17], 0, 0, Hyb::kTerminal });
 
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 3, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 4, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 4, BondData(Ord::kSingleBond));
   }
 
   mol.confs().emplace_back(Matrix3Xd::Zero(3, 5)).transpose() << -0.0261,
@@ -657,23 +657,23 @@ TEST(AddHSp3d2, Fixed1E01234) {
     auto mut = mol.mutator();
     mut.add_atom({ kPt[16], 5, 0, Hyb::kSP3D2 });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
 
     mut.add_atom({ kPt[16], 4, 0, Hyb::kSP3D2 });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
-    mut.add_bond(2, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(2, 3, BondData(Ord::kSingleBond));
 
     mut.add_atom({ kPt[16], 3, 0, Hyb::kSP3D2 });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
-    mut.add_bond(4, 5, BondData(Ord::kSingleBond));
+    mut.register_bond(4, 5, BondData(Ord::kSingleBond));
 
     mut.add_atom({ kPt[16], 2, 0, Hyb::kSP3D2 });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
-    mut.add_bond(6, 7, BondData(Ord::kSingleBond));
+    mut.register_bond(6, 7, BondData(Ord::kSingleBond));
 
     mut.add_atom({ kPt[16], 1, 0, Hyb::kSP3D2 });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
-    mut.add_bond(8, 9, BondData(Ord::kSingleBond));
+    mut.register_bond(8, 9, BondData(Ord::kSingleBond));
   }
 
   double bl = kPt[16].covalent_radius() + kPt[9].covalent_radius();
@@ -693,11 +693,11 @@ TEST(AddHSp3d2, Fixed2AxE0123) {
     mut.add_atom({ kPt[16], 1, 0, Hyb::kSP3D2 });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
 
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
-    mut.add_bond(1, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(2, 3, BondData(Ord::kSingleBond));
-    mut.add_bond(3, 4, BondData(Ord::kSingleBond));
-    mut.add_bond(4, 5, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(1, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(2, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(3, 4, BondData(Ord::kSingleBond));
+    mut.register_bond(4, 5, BondData(Ord::kSingleBond));
   }
 
   double ble = kPt[16].covalent_radius() + kPt[9].covalent_radius(),
@@ -718,11 +718,11 @@ TEST(AddHSp3d2, Fixed2AxEqE0123) {
     mut.add_atom({ kPt[16], 1, 0, Hyb::kSP3D2 });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
 
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
-    mut.add_bond(1, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(2, 3, BondData(Ord::kSingleBond));
-    mut.add_bond(3, 4, BondData(Ord::kSingleBond));
-    mut.add_bond(4, 5, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(1, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(2, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(3, 4, BondData(Ord::kSingleBond));
+    mut.register_bond(4, 5, BondData(Ord::kSingleBond));
   }
 
   Matrix3Xd &conf = mol.confs().emplace_back(Matrix3Xd::Zero(3, 6));
@@ -754,13 +754,13 @@ TEST(AddHSp3d2, Fixed3MerE012) {
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
 
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 3, BondData(Ord::kSingleBond));
-    mut.add_bond(3, 4, BondData(Ord::kSingleBond));
-    mut.add_bond(3, 5, BondData(Ord::kSingleBond));
-    mut.add_bond(5, 6, BondData(Ord::kSingleBond));
-    mut.add_bond(5, 7, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(3, 4, BondData(Ord::kSingleBond));
+    mut.register_bond(3, 5, BondData(Ord::kSingleBond));
+    mut.register_bond(5, 6, BondData(Ord::kSingleBond));
+    mut.register_bond(5, 7, BondData(Ord::kSingleBond));
   }
 
   Matrix3Xd &conf = mol.confs().emplace_back(Matrix3Xd::Zero(3, 8));
@@ -797,13 +797,13 @@ TEST(AddHSp3d2, Fixed3FacE012) {
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
 
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 3, BondData(Ord::kSingleBond));
-    mut.add_bond(3, 4, BondData(Ord::kSingleBond));
-    mut.add_bond(3, 5, BondData(Ord::kSingleBond));
-    mut.add_bond(5, 6, BondData(Ord::kSingleBond));
-    mut.add_bond(5, 7, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(3, 4, BondData(Ord::kSingleBond));
+    mut.register_bond(3, 5, BondData(Ord::kSingleBond));
+    mut.register_bond(5, 6, BondData(Ord::kSingleBond));
+    mut.register_bond(5, 7, BondData(Ord::kSingleBond));
   }
 
   Matrix3Xd &conf = mol.confs().emplace_back(Matrix3Xd::Zero(3, 8));
@@ -839,13 +839,13 @@ TEST(AddHSp3d2, Fixed4PlanarE01) {
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
 
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 3, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 4, BondData(Ord::kSingleBond));
-    mut.add_bond(4, 5, BondData(Ord::kSingleBond));
-    mut.add_bond(4, 6, BondData(Ord::kSingleBond));
-    mut.add_bond(4, 7, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 4, BondData(Ord::kSingleBond));
+    mut.register_bond(4, 5, BondData(Ord::kSingleBond));
+    mut.register_bond(4, 6, BondData(Ord::kSingleBond));
+    mut.register_bond(4, 7, BondData(Ord::kSingleBond));
   }
 
   Matrix3Xd &conf = mol.confs().emplace_back(Matrix3Xd::Zero(3, 8));
@@ -880,13 +880,13 @@ TEST(AddHSp3d2, Fixed4NonplanarE01) {
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
 
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 3, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 4, BondData(Ord::kSingleBond));
-    mut.add_bond(4, 5, BondData(Ord::kSingleBond));
-    mut.add_bond(4, 6, BondData(Ord::kSingleBond));
-    mut.add_bond(4, 7, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 4, BondData(Ord::kSingleBond));
+    mut.register_bond(4, 5, BondData(Ord::kSingleBond));
+    mut.register_bond(4, 6, BondData(Ord::kSingleBond));
+    mut.register_bond(4, 7, BondData(Ord::kSingleBond));
   }
 
   Matrix3Xd &conf = mol.confs().emplace_back(Matrix3Xd::Zero(3, 8));
@@ -918,11 +918,11 @@ TEST(AddHSp3d2, Fixed5E0) {
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
     mut.add_atom({ kPt[9], 0, 0, Hyb::kTerminal });
 
-    mut.add_bond(0, 1, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 2, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 3, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 4, BondData(Ord::kSingleBond));
-    mut.add_bond(0, 5, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 1, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 2, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 3, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 4, BondData(Ord::kSingleBond));
+    mut.register_bond(0, 5, BondData(Ord::kSingleBond));
   }
 
   Matrix3Xd &conf = mol.confs().emplace_back(Matrix3Xd::Zero(3, 6));

--- a/test/core/molecule/molecule_test.cpp
+++ b/test/core/molecule/molecule_test.cpp
@@ -68,16 +68,16 @@ TEST(Basic2DMoleculeTest, AddBondsTest) {
     bool success;
 
     auto mutator = ten.mutator();
-    std::tie(b1, success) = mutator.add_bond(0, 1, BondData(kSingleBond));
+    std::tie(b1, success) = mutator.register_bond(0, 1, BondData(kSingleBond));
     EXPECT_TRUE(success);
 
-    std::tie(b2, success) = mutator.add_bond(1, 0, BondData(kDoubleBond));
+    std::tie(b2, success) = mutator.register_bond(1, 0, BondData(kDoubleBond));
     EXPECT_EQ(b1, b2);
     EXPECT_FALSE(success);
   }
   {
     auto mutator = ten.mutator();
-    EXPECT_FALSE(mutator.add_bond(1, 0, BondData(kDoubleBond)).second);
+    EXPECT_FALSE(mutator.register_bond(1, 0, BondData(kDoubleBond)).second);
   }
 
   EXPECT_EQ(ten.num_bonds(), 1);
@@ -119,17 +119,17 @@ protected:
       }
       mutator.add_atom({ pt[11], 0, +1 });
 
-      mutator.add_bond(0, 1, BondData { kDoubleBond });
-      mutator.add_bond(0, 2, BondData { kSingleBond });
-      mutator.add_bond(1, 2, BondData { kSingleBond });
-      mutator.add_bond(2, 3, BondData { kSingleBond });
-      mutator.add_bond(3, 4, BondData { kSingleBond });
-      mutator.add_bond(4, 5, BondData { kSingleBond });
-      mutator.add_bond(0, 6, BondData { kSingleBond });
-      mutator.add_bond(1, 7, BondData { kSingleBond });
-      mutator.add_bond(2, 8, BondData { kSingleBond });
-      mutator.add_bond(3, 9, BondData { kSingleBond });
-      mutator.add_bond(3, 10, BondData { kSingleBond });
+      mutator.register_bond(0, 1, BondData { kDoubleBond });
+      mutator.register_bond(0, 2, BondData { kSingleBond });
+      mutator.register_bond(1, 2, BondData { kSingleBond });
+      mutator.register_bond(2, 3, BondData { kSingleBond });
+      mutator.register_bond(3, 4, BondData { kSingleBond });
+      mutator.register_bond(4, 5, BondData { kSingleBond });
+      mutator.register_bond(0, 6, BondData { kSingleBond });
+      mutator.register_bond(1, 7, BondData { kSingleBond });
+      mutator.register_bond(2, 8, BondData { kSingleBond });
+      mutator.register_bond(3, 9, BondData { kSingleBond });
+      mutator.register_bond(3, 10, BondData { kSingleBond });
     }
 
     ASSERT_EQ(mol_.num_atoms(), 12);
@@ -196,7 +196,7 @@ TEST_F(MoleculeTest, AddAtomsTest) {
 TEST_F(MoleculeTest, AddBonds) {
   {
     auto mutator = mol_.mutator();
-    mutator.add_bond(4, 11, {});
+    mutator.register_bond(4, 11, {});
   }
 
   EXPECT_EQ(mol_.num_bonds(), 12);
@@ -418,7 +418,7 @@ TEST(EraseNontrivialHydrogensTest, ExplicitH2) {
     auto mut = mol.mutator();
     mut.add_atom(pt[1]);
     mut.add_atom(pt[1]);
-    mut.add_bond(0, 1, BondData(kSingleBond));
+    mut.register_bond(0, 1, BondData(kSingleBond));
   }
 
   mol.erase_hydrogens();
@@ -446,8 +446,8 @@ TEST(EraseNontrivialHydrogensTest, BridgingH) {
     mut.add_atom(pt[5]);
     mut.add_atom(pt[1]);
     mut.add_atom(pt[5]);
-    mut.add_bond(0, 1, BondData(kSingleBond));
-    mut.add_bond(1, 2, BondData(kSingleBond));
+    mut.register_bond(0, 1, BondData(kSingleBond));
+    mut.register_bond(1, 2, BondData(kSingleBond));
   }
 
   mol.erase_hydrogens();
@@ -468,10 +468,10 @@ TEST(EraseNontrivialHydrogensTest, ChiralH) {
       mut.add_atom(pt[17]);
       mut.add_atom(pt[35]);
 
-      mut.add_bond(0, 1, BondData(kSingleBond));
-      mut.add_bond(0, 2, BondData(kSingleBond));
-      mut.add_bond(0, 3, BondData(kSingleBond));
-      mut.add_bond(0, 4, BondData(kSingleBond));
+      mut.register_bond(0, 1, BondData(kSingleBond));
+      mut.register_bond(0, 2, BondData(kSingleBond));
+      mut.register_bond(0, 3, BondData(kSingleBond));
+      mut.register_bond(0, 4, BondData(kSingleBond));
     }
 
     mol.erase_hydrogens();
@@ -495,10 +495,10 @@ TEST(EraseNontrivialHydrogensTest, ChiralH) {
       mut.add_atom(pt[17]);
       mut.add_atom(pt[35]);
 
-      mut.add_bond(0, 1, BondData(kSingleBond));
-      mut.add_bond(0, 2, BondData(kSingleBond));
-      mut.add_bond(0, 3, BondData(kSingleBond));
-      mut.add_bond(0, 4, BondData(kSingleBond));
+      mut.register_bond(0, 1, BondData(kSingleBond));
+      mut.register_bond(0, 2, BondData(kSingleBond));
+      mut.register_bond(0, 3, BondData(kSingleBond));
+      mut.register_bond(0, 4, BondData(kSingleBond));
     }
 
     mol.erase_hydrogens();
@@ -657,7 +657,7 @@ TEST_F(MoleculeTest, MergeOther) {
     mut.add_atom(pt[6]);
     mut.add_atom(pt[6]);
 
-    mut.add_bond(0, 1, BondData(kSingleBond));
+    mut.register_bond(0, 1, BondData(kSingleBond));
   }
 
   mol_.merge(mol);
@@ -730,16 +730,16 @@ TEST(SanitizeTest, FindRingsTest) {
       mut.add_atom(pt[6]);
     }
 
-    mut.add_bond(0, 3, BondData(kSingleBond));
-    mut.add_bond(0, 6, BondData(kSingleBond));
-    mut.add_bond(1, 4, BondData(kSingleBond));
-    mut.add_bond(1, 5, BondData(kSingleBond));
-    mut.add_bond(1, 7, BondData(kSingleBond));
-    mut.add_bond(2, 5, BondData(kSingleBond));
-    mut.add_bond(3, 4, BondData(kSingleBond));
-    mut.add_bond(3, 6, BondData(kSingleBond));
-    mut.add_bond(4, 6, BondData(kSingleBond));
-    mut.add_bond(5, 7, BondData(kSingleBond));
+    mut.register_bond(0, 3, BondData(kSingleBond));
+    mut.register_bond(0, 6, BondData(kSingleBond));
+    mut.register_bond(1, 4, BondData(kSingleBond));
+    mut.register_bond(1, 5, BondData(kSingleBond));
+    mut.register_bond(1, 7, BondData(kSingleBond));
+    mut.register_bond(2, 5, BondData(kSingleBond));
+    mut.register_bond(3, 4, BondData(kSingleBond));
+    mut.register_bond(3, 6, BondData(kSingleBond));
+    mut.register_bond(4, 6, BondData(kSingleBond));
+    mut.register_bond(5, 7, BondData(kSingleBond));
 
     for (int i: { 1, 3, 4, 5, 6 }) {
       mol.atom(i).data().set_implicit_hydrogens(1);
@@ -763,9 +763,9 @@ TEST(SanitizeTest, ConjugatedTest) {
     mut.add_atom(pt[8]);
     mut.add_atom(pt[8]);
 
-    mut.add_bond(0, 1, BondData(kSingleBond));
-    mut.add_bond(0, 2, BondData(kDoubleBond));
-    mut.add_bond(0, 3, BondData(kSingleBond));
+    mut.register_bond(0, 1, BondData(kSingleBond));
+    mut.register_bond(0, 2, BondData(kDoubleBond));
+    mut.register_bond(0, 3, BondData(kSingleBond));
 
     mol.atom(1).data().set_implicit_hydrogens(3);
     mol.atom(3).data().set_implicit_hydrogens(1);
@@ -799,7 +799,7 @@ TEST(SanitizeTest, ConjugatedTest) {
     mut.add_atom(pt[6]);
 
     for (int i = 0; i < 5; ++i) {
-      mut.add_bond(i, (i + 1) % 5, BondData(kAromaticBond));
+      mut.register_bond(i, (i + 1) % 5, BondData(kAromaticBond));
       mol.atom(i).data().set_implicit_hydrogens(1);
     }
   }
@@ -836,11 +836,11 @@ TEST(SanitizeTest, ConjugatedTest) {
     for (int i = 0; i < 6; ++i) {
       mut.add_atom(pt[6]);
     }
-    mut.add_bond(0, 4, BondData(kDoubleBond));
-    mut.add_bond(0, 1, BondData(kDoubleBond));
-    mut.add_bond(1, 3, BondData(kSingleBond));
-    mut.add_bond(3, 2, BondData(kTripleBond));
-    mut.add_bond(4, 5, BondData(kSingleBond));
+    mut.register_bond(0, 4, BondData(kDoubleBond));
+    mut.register_bond(0, 1, BondData(kDoubleBond));
+    mut.register_bond(1, 3, BondData(kSingleBond));
+    mut.register_bond(3, 2, BondData(kTripleBond));
+    mut.register_bond(4, 5, BondData(kSingleBond));
 
     for (int i: { 1, 2, 4 }) {
       mol.atom(i).data().set_implicit_hydrogens(1);
@@ -876,10 +876,10 @@ TEST(SanitizeTest, ConjugatedTest) {
     mut.add_atom(pt[7]);
     mut.add_atom(pt[6]);
     mut.add_atom(pt[7]);
-    mut.add_bond(0, 3, BondData(kDoubleBond));
-    mut.add_bond(0, 4, BondData(kSingleBond));
-    mut.add_bond(1, 2, BondData(kSingleBond));
-    mut.add_bond(1, 4, BondData(kSingleBond));
+    mut.register_bond(0, 3, BondData(kDoubleBond));
+    mut.register_bond(0, 4, BondData(kSingleBond));
+    mut.register_bond(1, 2, BondData(kSingleBond));
+    mut.register_bond(1, 4, BondData(kSingleBond));
 
     for (int i: { 1, 4 }) {
       mol.atom(i).data().set_implicit_hydrogens(1);
@@ -915,11 +915,11 @@ TEST(SanitizeTest, AromaticTest) {
     mut.add_atom(pt[6]);
     mut.add_atom(pt[6]);
 
-    mut.add_bond(0, 1, BondData(kSingleBond));
-    mut.add_bond(1, 3, BondData(kDoubleBond));
-    mut.add_bond(3, 2, BondData(kSingleBond));
-    mut.add_bond(2, 4, BondData(kDoubleBond));
-    mut.add_bond(4, 0, BondData(kSingleBond));
+    mut.register_bond(0, 1, BondData(kSingleBond));
+    mut.register_bond(1, 3, BondData(kDoubleBond));
+    mut.register_bond(3, 2, BondData(kSingleBond));
+    mut.register_bond(2, 4, BondData(kDoubleBond));
+    mut.register_bond(4, 0, BondData(kSingleBond));
 
     for (int i = 0; i < 5; ++i) {
       mol.atom(i).data().set_implicit_hydrogens(1);
@@ -972,11 +972,11 @@ TEST(SanitizeTest, AromaticTest) {
     mut.add_atom(pt[6]);
     mut.add_atom(pt[6]);
 
-    mut.add_bond(0, 1, BondData(kSingleBond));
-    mut.add_bond(1, 2, BondData(kDoubleBond));
-    mut.add_bond(2, 3, BondData(kSingleBond));
-    mut.add_bond(3, 4, BondData(kDoubleBond));
-    mut.add_bond(4, 0, BondData(kSingleBond));
+    mut.register_bond(0, 1, BondData(kSingleBond));
+    mut.register_bond(1, 2, BondData(kDoubleBond));
+    mut.register_bond(2, 3, BondData(kSingleBond));
+    mut.register_bond(3, 4, BondData(kDoubleBond));
+    mut.register_bond(4, 0, BondData(kSingleBond));
 
     for (int i = 0; i < 5; ++i) {
       mol.atom(i).data().set_implicit_hydrogens(1);
@@ -1020,14 +1020,14 @@ TEST(SanitizeTest, AromaticTest) {
     mut.add_atom(pt[8]);
     mut.add_atom(pt[8]);
 
-    mut.add_bond(0, 1, BondData(kSingleBond));
-    mut.add_bond(1, 2, BondData(kDoubleBond));
-    mut.add_bond(2, 3, BondData(kSingleBond));
-    mut.add_bond(3, 4, BondData(kSingleBond));
-    mut.add_bond(4, 5, BondData(kDoubleBond));
-    mut.add_bond(5, 0, BondData(kSingleBond));
-    mut.add_bond(0, 6, BondData(kDoubleBond));
-    mut.add_bond(3, 7, BondData(kDoubleBond));
+    mut.register_bond(0, 1, BondData(kSingleBond));
+    mut.register_bond(1, 2, BondData(kDoubleBond));
+    mut.register_bond(2, 3, BondData(kSingleBond));
+    mut.register_bond(3, 4, BondData(kSingleBond));
+    mut.register_bond(4, 5, BondData(kDoubleBond));
+    mut.register_bond(5, 0, BondData(kSingleBond));
+    mut.register_bond(0, 6, BondData(kDoubleBond));
+    mut.register_bond(3, 7, BondData(kDoubleBond));
 
     for (int i: { 1, 2, 4, 5 }) {
       mol.atom(i).data().set_implicit_hydrogens(1);
@@ -1087,11 +1087,11 @@ TEST(SanitizeTest, FusedAromaticTest) {
       }
     }
     for (int i = 0; i < 6; ++i) {
-      mut.add_bond(i, (i + 1) % 6, BondData(kAromaticBond));
-      mut.add_bond(i + 6, (i + 1) % 6 + 6, BondData(kAromaticBond));
+      mut.register_bond(i, (i + 1) % 6, BondData(kAromaticBond));
+      mut.register_bond(i + 6, (i + 1) % 6 + 6, BondData(kAromaticBond));
     }
-    mut.add_bond(0, 11, BondData(kSingleBond));
-    mut.add_bond(5, 6, BondData(kSingleBond));
+    mut.register_bond(0, 11, BondData(kSingleBond));
+    mut.register_bond(5, 6, BondData(kSingleBond));
   }
   verify_bcb();
 
@@ -1142,12 +1142,12 @@ TEST(SanitizeTest, FusedAromaticTest) {
       }
     }
     for (int i = 0; i < 6; ++i) {
-      ASSERT_TRUE(mut.add_bond(i, i + 1, BondData(kAromaticBond)).second);
+      ASSERT_TRUE(mut.register_bond(i, i + 1, BondData(kAromaticBond)).second);
     }
-    ASSERT_TRUE(mut.add_bond(6, 0, BondData(kSingleBond)).second);
+    ASSERT_TRUE(mut.register_bond(6, 0, BondData(kSingleBond)).second);
     for (int i = 6; i < 10; ++i) {
       ASSERT_TRUE(
-          mut.add_bond(i, (i + 1) % 10, BondData(kAromaticBond)).second);
+          mut.register_bond(i, (i + 1) % 10, BondData(kAromaticBond)).second);
     }
   }
   verify_azulene();
@@ -1183,17 +1183,17 @@ TEST(SanitizeTest, Samples) {
     mut.add_atom(pt[6]);
     mut.add_atom(pt[7]);
 
-    mut.add_bond(0, 1, BondData(kDoubleBond));
-    mut.add_bond(1, 2, BondData(kAromaticBond));
-    mut.add_bond(2, 3, BondData(kAromaticBond));
-    mut.add_bond(3, 4, BondData(kAromaticBond));
-    mut.add_bond(4, 5, BondData(kAromaticBond));
-    mut.add_bond(5, 6, BondData(kAromaticBond));
-    mut.add_bond(6, 2, BondData(kAromaticBond));
-    mut.add_bond(6, 7, BondData(kAromaticBond));
-    mut.add_bond(7, 8, BondData(kAromaticBond));
-    mut.add_bond(8, 9, BondData(kAromaticBond));
-    mut.add_bond(9, 1, BondData(kAromaticBond));
+    mut.register_bond(0, 1, BondData(kDoubleBond));
+    mut.register_bond(1, 2, BondData(kAromaticBond));
+    mut.register_bond(2, 3, BondData(kAromaticBond));
+    mut.register_bond(3, 4, BondData(kAromaticBond));
+    mut.register_bond(4, 5, BondData(kAromaticBond));
+    mut.register_bond(5, 6, BondData(kAromaticBond));
+    mut.register_bond(6, 2, BondData(kAromaticBond));
+    mut.register_bond(6, 7, BondData(kAromaticBond));
+    mut.register_bond(7, 8, BondData(kAromaticBond));
+    mut.register_bond(8, 9, BondData(kAromaticBond));
+    mut.register_bond(9, 1, BondData(kAromaticBond));
   }
 
   for (int i: { 3, 4, 8, 9 })
@@ -1226,12 +1226,12 @@ TEST(SanitizeTest, Samples) {
     mut.add_atom(pt[7]);
     mut.add_atom(pt[7]);
 
-    mut.add_bond(0, 1, BondData(kDoubleBond));
-    mut.add_bond(1, 2, BondData(kAromaticBond));
-    mut.add_bond(2, 3, BondData(kAromaticBond));
-    mut.add_bond(3, 4, BondData(kAromaticBond));
-    mut.add_bond(4, 5, BondData(kAromaticBond));
-    mut.add_bond(5, 1, BondData(kAromaticBond));
+    mut.register_bond(0, 1, BondData(kDoubleBond));
+    mut.register_bond(1, 2, BondData(kAromaticBond));
+    mut.register_bond(2, 3, BondData(kAromaticBond));
+    mut.register_bond(3, 4, BondData(kAromaticBond));
+    mut.register_bond(4, 5, BondData(kAromaticBond));
+    mut.register_bond(5, 1, BondData(kAromaticBond));
   }
 
   for (int i: { 3, 5 })
@@ -1259,10 +1259,10 @@ TEST(SanitizeTest, NonstandardTest) {
     mut.add_atom(pt[8]);
     mut.add_atom(pt[8]);
 
-    mut.add_bond(0, 1, BondData(kDoubleBond));
-    mut.add_bond(0, 2, BondData(kDoubleBond));
-    mut.add_bond(0, 3, BondData(kDoubleBond));
-    mut.add_bond(0, 4, BondData(kDoubleBond));
+    mut.register_bond(0, 1, BondData(kDoubleBond));
+    mut.register_bond(0, 2, BondData(kDoubleBond));
+    mut.register_bond(0, 3, BondData(kDoubleBond));
+    mut.register_bond(0, 4, BondData(kDoubleBond));
   }
 
   {
@@ -1284,7 +1284,7 @@ TEST(SanitizeTest, NonstandardTest) {
     mut.add_atom(pt[6]);
 
     for (int i = 0; i < 5; ++i) {
-      mut.add_bond(i, (i + 1) % 5, BondData(kAromaticBond));
+      mut.register_bond(i, (i + 1) % 5, BondData(kAromaticBond));
       mol.atom(i).data().set_implicit_hydrogens(1);
     }
   }
@@ -1310,7 +1310,7 @@ TEST(SanitizeTest, NonstandardTest) {
     mut.add_atom(pt[6]);
 
     for (int i = 0; i < 5; ++i) {
-      mut.add_bond(i, (i + 1) % 5, BondData(kAromaticBond));
+      mut.register_bond(i, (i + 1) % 5, BondData(kAromaticBond));
       mol.atom(i).data().set_implicit_hydrogens(1);
     }
   }
@@ -1348,8 +1348,8 @@ TEST(SanitizeTest, ErrorMolTest) {
     mut.add_atom(pt[8]);
     mut.add_atom(pt[8]);
     mut.add_atom(pt[8]);
-    mut.add_bond(0, 1, BondData(kDoubleBond));
-    mut.add_bond(0, 2, BondData(kDoubleBond));
+    mut.register_bond(0, 1, BondData(kDoubleBond));
+    mut.register_bond(0, 2, BondData(kDoubleBond));
   }
 
   {
@@ -1365,9 +1365,9 @@ TEST(SanitizeTest, ErrorMolTest) {
     for (int i = 0; i < 4; ++i) {
       mut.add_atom(pt[6]);
     }
-    mut.add_bond(0, 1, BondData(kAromaticBond));
-    mut.add_bond(1, 2, BondData(kAromaticBond));
-    mut.add_bond(2, 3, BondData(kAromaticBond));
+    mut.register_bond(0, 1, BondData(kAromaticBond));
+    mut.register_bond(1, 2, BondData(kAromaticBond));
+    mut.register_bond(2, 3, BondData(kAromaticBond));
   }
 
   {
@@ -1413,12 +1413,12 @@ TEST(SanitizeTest, ErrorMolTest) {
     mut.add_atom(pt[6]);
     mut.add_atom(pt[6]);
 
-    mut.add_bond(0, 1, BondData(kAromaticBond));
-    mut.add_bond(1, 2, BondData(kAromaticBond));
-    mut.add_bond(2, 3, BondData(kAromaticBond));
-    mut.add_bond(3, 4, BondData(kAromaticBond));
-    mut.add_bond(4, 5, BondData(kAromaticBond));
-    mut.add_bond(5, 0, BondData(kAromaticBond));
+    mut.register_bond(0, 1, BondData(kAromaticBond));
+    mut.register_bond(1, 2, BondData(kAromaticBond));
+    mut.register_bond(2, 3, BondData(kAromaticBond));
+    mut.register_bond(3, 4, BondData(kAromaticBond));
+    mut.register_bond(4, 5, BondData(kAromaticBond));
+    mut.register_bond(5, 0, BondData(kAromaticBond));
 
     for (int i = 0; i < 6; ++i) {
       mol.atom(i).data().set_implicit_hydrogens(1);
@@ -1441,10 +1441,10 @@ TEST(SanitizeTest, ErrorMolTest) {
     mut.add_atom(pt[8]);
     mut.add_atom(pt[8]);
 
-    mut.add_bond(0, 1, BondData(kDoubleBond));
-    mut.add_bond(0, 2, BondData(kDoubleBond));
-    mut.add_bond(0, 3, BondData(kDoubleBond));
-    mut.add_bond(0, 4, BondData(kDoubleBond));
+    mut.register_bond(0, 1, BondData(kDoubleBond));
+    mut.register_bond(0, 2, BondData(kDoubleBond));
+    mut.register_bond(0, 3, BondData(kDoubleBond));
+    mut.register_bond(0, 4, BondData(kDoubleBond));
   }
 
   {

--- a/test/core/molecule/substructure_test.cpp
+++ b/test/core/molecule/substructure_test.cpp
@@ -65,17 +65,17 @@ protected:
       }
       mutator.add_atom({ kPt[11], 0, +1 });
 
-      mutator.add_bond(0, 4, BondData { constants::kSingleBond });
-      mutator.add_bond(3, 2, BondData { constants::kSingleBond });
-      mutator.add_bond(3, 1, BondData { constants::kDoubleBond });
-      mutator.add_bond(1, 2, BondData { constants::kSingleBond });
-      mutator.add_bond(2, 0, BondData { constants::kSingleBond });
-      mutator.add_bond(4, 5, BondData { constants::kSingleBond });
-      mutator.add_bond(3, 6, BondData { constants::kSingleBond });
-      mutator.add_bond(1, 7, BondData { constants::kSingleBond });
-      mutator.add_bond(2, 8, BondData { constants::kSingleBond });
-      mutator.add_bond(0, 9, BondData { constants::kSingleBond });
-      mutator.add_bond(0, 10, BondData { constants::kSingleBond });
+      mutator.register_bond(0, 4, BondData { constants::kSingleBond });
+      mutator.register_bond(3, 2, BondData { constants::kSingleBond });
+      mutator.register_bond(3, 1, BondData { constants::kDoubleBond });
+      mutator.register_bond(1, 2, BondData { constants::kSingleBond });
+      mutator.register_bond(2, 0, BondData { constants::kSingleBond });
+      mutator.register_bond(4, 5, BondData { constants::kSingleBond });
+      mutator.register_bond(3, 6, BondData { constants::kSingleBond });
+      mutator.register_bond(1, 7, BondData { constants::kSingleBond });
+      mutator.register_bond(2, 8, BondData { constants::kSingleBond });
+      mutator.register_bond(0, 9, BondData { constants::kSingleBond });
+      mutator.register_bond(0, 10, BondData { constants::kSingleBond });
     }
 
     ASSERT_EQ(mol_.num_atoms(), 12);
@@ -399,17 +399,17 @@ protected:
       }
       mutator.add_atom({ kPt[11], 0, +1 });
 
-      mutator.add_bond(0, 4, BondData { constants::kSingleBond });
-      mutator.add_bond(3, 2, BondData { constants::kSingleBond });
-      mutator.add_bond(3, 1, BondData { constants::kDoubleBond });
-      mutator.add_bond(1, 2, BondData { constants::kSingleBond });
-      mutator.add_bond(2, 0, BondData { constants::kSingleBond });
-      mutator.add_bond(4, 5, BondData { constants::kSingleBond });
-      mutator.add_bond(3, 6, BondData { constants::kSingleBond });
-      mutator.add_bond(1, 7, BondData { constants::kSingleBond });
-      mutator.add_bond(2, 8, BondData { constants::kSingleBond });
-      mutator.add_bond(0, 9, BondData { constants::kSingleBond });
-      mutator.add_bond(0, 10, BondData { constants::kSingleBond });
+      mutator.register_bond(0, 4, BondData { constants::kSingleBond });
+      mutator.register_bond(3, 2, BondData { constants::kSingleBond });
+      mutator.register_bond(3, 1, BondData { constants::kDoubleBond });
+      mutator.register_bond(1, 2, BondData { constants::kSingleBond });
+      mutator.register_bond(2, 0, BondData { constants::kSingleBond });
+      mutator.register_bond(4, 5, BondData { constants::kSingleBond });
+      mutator.register_bond(3, 6, BondData { constants::kSingleBond });
+      mutator.register_bond(1, 7, BondData { constants::kSingleBond });
+      mutator.register_bond(2, 8, BondData { constants::kSingleBond });
+      mutator.register_bond(0, 9, BondData { constants::kSingleBond });
+      mutator.register_bond(0, 10, BondData { constants::kSingleBond });
     }
 
     ASSERT_EQ(mol_.num_atoms(), 12);

--- a/test/fmt/mol2_test.cpp
+++ b/test/fmt/mol2_test.cpp
@@ -1688,7 +1688,7 @@ TEST_F(Mol2Test, Write2D) {
     for (int i = 0; i < 6; ++i)
       mut.add_atom(kPt[6]);
     for (int i = 0; i < 5; ++i)
-      mut.add_bond(i, i + 1, BondData { constants::kSingleBond });
+      mut.register_bond(i, i + 1, BondData { constants::kSingleBond });
   }
 
   guess_hydrogens_2d(m);

--- a/test/fmt/sdf_test.cpp
+++ b/test/fmt/sdf_test.cpp
@@ -754,7 +754,7 @@ TEST(SDFFormatTest, V2000Correct) {
     auto mut = mol.mutator();
     mut.add_atom(kPt[6]);
     mut.add_atom(kPt[6]);
-    mut.add_bond(0, 1, BondData(constants::kSingleBond));
+    mut.register_bond(0, 1, BondData(constants::kSingleBond));
   }
 
   mol[1].data().set_isotope(13).set_formal_charge(1);
@@ -805,7 +805,7 @@ TEST(SDFFormatTest, V3000Correct) {
     auto mut = mol.mutator();
     mut.add_atom(kPt[6]);
     mut.add_atom(kPt[6]);
-    mut.add_bond(0, 1, BondData(constants::kSingleBond));
+    mut.register_bond(0, 1, BondData(constants::kSingleBond));
   }
 
   mol[1].data().set_isotope(13).set_formal_charge(1);


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [ ] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [ ] Have you built the project locally without any warnings and errors?
- [ ] Do all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #...

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it rewrites `Graph`’s core adjacency storage and edge/node mutation paths (CSR offsets, compaction, and edge publishing), which can subtly break traversal/erase semantics and invalidate performance assumptions across molecule and format code.
> 
> **Overview**
> **Switches `Graph` adjacency storage to a CSR-style flat buffer.** Per-node `std::vector` adjacency lists are replaced with `offsets_` + flat `adj_list_`, and all adjacency access/erase logic is rewritten to shift/compact the flat buffer and keep offsets consistent.
> 
> **Introduces bulk edge insertion and deprecates single-edge insertion.** Adds `add_edges()` (and exposes `StoredEdge`) plus a `publish_edges_from()` delta update path; `add_edge()` is now deprecated/slow and many call sites (including Boost adaptor and internal tools/tests) are migrated to batch insertion.
> 
> **Changes molecule mutation semantics to batch bond additions.** `MoleculeMutator::add_bond` becomes `register_bond`, buffering bonds until `finalize()` (which now adds registered bonds before applying deletions); Python bindings/docs/tests are updated to `register_bond` and return a bond index instead of a bond proxy, and some algorithms (e.g. 3D connectivity guessing) explicitly `finalize()` before downstream processing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3cc669220e112189f7283f8a011574022d90d8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->