### PR TITLE
chore: improve contributor and agent onboarding

### DIFF
--- a/.claude/skills/sanitizer-build/SKILL.md
+++ b/.claude/skills/sanitizer-build/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: sanitizer-build
+description: >-
+  Configure and build the `sanitizers` (ASan/UBSan) CMake variant of nurikit.
+  Use when building, configuring, or running the sanitizer build — or when a
+  sanitizer build fails to link/run under GCC. Covers the clang++ requirement
+  (active GCC bug), the required CMake flags, and the build-time environment
+  variables.
+---
+
+# Sanitizer builds
+
+Sanitizer builds (the `sanitizers` CMake variant) must use `clang++` due to an
+active GCC bug. Building the sanitizer variant with GCC will fail to link or run
+correctly.
+
+## Configure
+
+Use `clang++` and point it at the GCC install so the correct runtime is found:
+
+```bash
+cmake -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_CXX_FLAGS="--gcc-install-dir=$(dirname "$(gcc -print-libgcc-file-name)")" \
+  ...
+```
+
+## Build
+
+Set these environment variables at build time:
+
+```bash
+LD_PRELOAD="$(gcc -print-file-name=libubsan.so.1)" \
+  ASAN_OPTIONS="detect_odr_violation=0 detect_leaks=0" \
+  cmake --build ...
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# Agent Instructions
+
+## Operating rules
+
+**Always**
+
+- **Tooling** - Assume tools like `cmake`, C++ compiler(s),
+  `clang-format`/`clang-tidy`, `pre-commit`, and `python` are installed
+  globally; don't check. C++ deps are fetched by CPM at configure time. If a
+  tool is genuinely missing, surface the error instead of working around it.
+- **Build dir** - Drive the project CMake-first through `build/<variant>` at the
+  repo root; see `cmake-variants.json` for variants.
+- **Reconfigure** - Re-run the configure step after pulling or switching
+  branches.
+
+**When you change...**
+
+- **C++ code** - Follow the style guide (Google C++ with tweaks; see
+  `CONTRIBUTING.md`) and the surrounding code. Notably: `lower_case` names for
+  all functions; `.cpp` sources; exceptions never escape the public API;
+  non-trivially-destructible static-storage objects must be `const`/`constexpr`.
+  Format `clang-format`, lint `clang-tidy`.
+- **Python code** - Follow PEP 8; `ruff` handles format and import order.
+- **Commits** - Use Conventional Commits (`gitlint`). Commit on a feature
+  branch, never `main` or `release/*`.
+- **Tests** - Add tests for new features. C++ under `test/` (GoogleTest, via
+  `nuri_add_test()`); Python under `python/test/` (pytest).
+- **Docs** - C++ is Doxygen (`docs/`), Python is Sphinx (`python/docs/`); keep
+  docstrings and doc sources in sync. For Python docstrings, always use
+  Sphinx-compatible reST.
+- **Format & lint** - C++ with `scripts/run_clang_tools.sh` (slow, run only when
+  needed). `ruff` and other checks run via `pre-commit`.
+
+### Caveats
+
+- pre-commit hooks must run at every commit. If not, run
+  `pre-commit install --install-hooks --overwrite` to fix.
+
+## Notable dev commands
+
+Use `ninja` generator for faster compilation.
+
+Below, `<build>` is `build/<variant>`; `<variant>` is one defined in
+`cmake-variants.json`: `debug`, `release`, `minsize`, `reldeb`, `coverage`,
+`sanitizers`, `fuzzer`. Prefer:
+
+- `coverage` for local development and debugging,
+- `sanitizers` for memory and UB safety, and
+- `reldeb` for performance profiling.
+
+Avoid using others unless explicitly requested.
+
+| Task              | Command                                                                                                                                 |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Configure         | `cmake -G Ninja -S . -B <build> -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DNURI_BUILD_DEV_MODE=ON && cp <build>/compile_commands.json build/` |
+| Build             | `cmake --build <build> -j"$(nproc)"`                                                                                                    |
+| C++ tests         | `ctest -j"$(nproc)" --test-dir <build> --output-on-failure`                                                                             |
+| Python tests      | `PYTHONPATH="$PWD/python/src" pytest -vs python/test`                                                                                   |
+| Python doctest    | `PYTHONPATH="$PWD/python/src" cmake --build <build> --target NuriPythonDoctest`                                                         |
+| Format & lint C++ | `scripts/run_clang_tools.sh -j"$(nproc)" [files...]`                                                                                    |
+| Coverage          | `scripts/check_coverage.sh <build>`                                                                                                     |
+| C++ API docs      | `cmake --build <build> --target NuriDocs`                                                                                               |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,11 +35,13 @@ include(NuriKitUtils)
 nuri_get_version()
 project(NuriKit VERSION "${NURI_CORE_VERSION}" LANGUAGES CXX)
 
+option(NURI_BUILD_DEV_MODE "Turn on development options" OFF)
+
 option(NURI_BUILD_LIB "Build NuriKit library" ON)
 option(NURI_BUILD_PYTHON "Build Python bindings" ON)
-option(NURI_BUILD_DOCS "Build documentation" OFF)
-option(NURI_BUILD_PYTHON_DOCS "Build python documentation" OFF)
-option(NURI_BUILD_PYTHON_DOCTEST "Build python doctest" OFF)
+option(NURI_BUILD_DOCS "Build documentation" ${NURI_BUILD_DEV_MODE})
+option(NURI_BUILD_PYTHON_DOCS "Build python documentation" ${NURI_BUILD_DEV_MODE})
+option(NURI_BUILD_PYTHON_DOCTEST "Build python doctest" ${NURI_BUILD_DEV_MODE})
 
 option(NURI_INSTALL_RPATH "Install with RPATH when building full library" ON)
 
@@ -51,11 +53,12 @@ option(NURI_ENABLE_SANITIZERS "Enable sanitizers for debug build" OFF)
 option(NURI_BUILD_FUZZING "Enable fuzzing build" OFF)
 option(NURI_BUILD_BENCHMARK "Enable benchmark build" OFF)
 
-option(NURI_BUILD_PYTHON_STUBS "Build python stub files" OFF)
+option(NURI_BUILD_PYTHON_STUBS "Build python stub files" ${NURI_BUILD_DEV_MODE})
 option(NURI_PREBUILT_ABSL "Download prebuilt abseil binary" OFF)
 set(NURI_FORCE_VERSION "" CACHE STRING "Set NuriKit version to this value")
 mark_as_advanced(
   NURI_BUILD_PYTHON_STUBS
+  NURI_BUILD_DEV_MODE
   NURI_PREBUILT_ABSL
   NURI_FORCE_VERSION
 )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,9 @@ If you've found a bug, please create an issue including the following
 information in your report:
 
 - The version or commit SHA of NuriKit you're using.
-- The version of Python you're using (if it's related to the NuriKit
-  python package).
-- The OS and version you're using (currently, only Ubuntu 20.04 is supported).
+- The version of Python you're using (if it's related to the NuriKit python
+  package).
+- The OS and version you're using.
 - A clear and concise description of what the bug is.
 - A minimal code snippet that reproduces the bug.
 
@@ -34,86 +34,44 @@ following information:
 
 ## Developer guide
 
-In this section,
-
-> The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-> "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be
-> interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
-
 ### Setting up the development environment
 
-Basically, you will be OK with the default packages provided by Ubuntu 20.04
-LTS. The specific requirements for building NuriKit are:
+Basically, you will be OK with the default packages provided by Ubuntu 20.04+.
+The specific requirements for building NuriKit are:
 
-- Linux (might support other OSes in the future)
+- Linux (macOS builds in CI, but is untested as a development platform)
 - [Git](https://git-scm.com/)
-- [CMake](https://cmake.org/), version 3.16 or later
+- [CMake](https://cmake.org/), version 3.16+
 - C/C++ Compilers
-  - [GCC](https://gcc.gnu.org/), version 9 or later
-  - [Clang](https://clang.llvm.org/), version 10 or later
+  - [GCC](https://gcc.gnu.org/), version 9+
+  - [Clang](https://clang.llvm.org/), version 10+
 
-Also, you SHOULD have
+Also, you should have
 [installed the latest version of pre-commit](https://pre-commit.com/#install)
 and run `pre-commit install --install-hooks` in the root of the repository.
 
 clang-format and clang-tidy are used to format and lint the source code. You
-SHOULD run these tools before submitting the PR. You can run the tools with the
-provided script: `./scripts/run_clang_tools.sh`. This script will run the tools
-on all source files, and will fail if any of the tools report any errors. You
-can also run the tools on specific files by passing the file paths as arguments
-to the script:
+should run these tools before submitting the PR. You can run the tools with
+the provided script: `./scripts/run_clang_tools.sh`:
 
 ```shellscript
-./scripts/run_clang_tools.sh src/atom.cpp src/atom.h
+# All files
+./scripts/run_clang_tools.sh [-j<nproc>]
+# Specific files
+./scripts/run_clang_tools.sh [-j<nproc>] src/core/element.cpp include/nuri/core/element.h
 ```
 
-clang-format and clang-tidy MUST be installed on your system to run the script.
-Version 15 of clang-format and clang-tidy are REQUIRED.
-
-:ledger: **Note to seoklab members**: seoklab compute cluster already has the
-latest version of pre-commit, clang-format, and clang-tidy installed. You don't
-need to install it again if you're developing on the cluster.
-
-### Building NuriKit
-
-To build NuriKit, you MUST clone the repository:
-
-```shellscript
-git clone git@github.com:seoklab/nurikit.git
-```
-
-Then you can build NuriKit using CMake:
-
-```shellscript
-mkdir build && cd build
-cmake ..
-cmake --build . -j
-```
-
-The complete build options could be listed with `cmake -LH ..` command in the
-build directory.
-
-:ledger: **Note to seoklab members**: seoklab compute cluster restricts the
-number of cores that can be used by a single user. If you're developing on the
-cluster, you might have to run the above command in a compute node, or replace
-the `-j` option with `-j4`:
-
-```shellscript
-cmake --build . -j4
-```
-
-### Branching model
-
-New branch MUST conform to the following naming convention:
-`<user id>/issue-<number>`. For example, if a user with id `galaxy` is working
-on issue `#123`, one MUST create a new branch named `galaxy/issue-123`. The
-commit to the `main` branch MUST be done via a pull request. An issue is
-REQUIRED for each new feature or bug fix.
+The script assumes version 16+ of both tools. CI pins the version to a specific
+major release; we recommend the same version for local development to avoid
+unnecessary churn. Refer
+[.github/workflows/_run-clang-tools.yaml](.github/workflows/_run-clang-tools.yaml)
+for the exact version used in CI.
 
 ### Commit messages
 
-The [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style
-for commit messages MUST be used. This will help us to automatically generate
+We recommend the
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style
+for commit messages. This will help us to automatically generate
 changelogs and release notes. We've setup the pre-commit hook to check the
 commit messages, so it will complain if you don't follow the convention. If
 you're not sure how to write a commit message, please check out
@@ -123,30 +81,29 @@ you're not sure how to write a commit message, please check out
 
 #### C++
 
-All code written in C++ SHOULD follow our C++ style guide. It is based on the
+All code written in C++ should follow our C++ style guide. It is based on the
 [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
 However, some of the rules are tailored to our needs. These are the rules that
 are different from the Google C++ Style Guide:
 
 - [Static storage duration](http://en.cppreference.com/w/cpp/language/storage_duration#Storage_duration) objects that are not
   [trivially destructible](http://en.cppreference.com/w/cpp/types/is_destructible)
-  are allowed, but they SHOULD be declared `const` and MUST NOT reference other
+  are allowed, but they should be declared `const` and must not reference other
   global variables that are not in the same translation unit. This includes
   references to other global variables in the constructor of the global
   variable. This is to avoid the
   [static initialization order fiasco](https://isocpp.org/wiki/faq/ctors#static-init-order).
   Prefer `constexpr` variables over `const` variables if possible.
-- The use of `explicit` keyword for single-argument constructors is OPTIONAL.
-- We allow exceptions inside *internal functions*[^1], but they MUST NOT escape
+- The use of `explicit` keyword for single-argument constructors is optional.
+- We allow exceptions inside *internal functions*[^1], but they must not escape
   the public C++ API.
-- All functions, including member functions, MUST follow the
-  naming convention of `lower_case`. This is to match the Python naming
-  convention.
-- For source files, `.cpp` extensions MUST be used.
-- Code SHOULD be formatted using `clang-format`, with the provided
-  `.clang-format` file. If part of the code needs to be formatted manually
-  for some reasons, `// clang-format off` and `// clang-format on` comments MAY
-  be used.
+- All functions, including member functions, must follow the naming convention
+  of `lower_case`. This is to match the Python naming convention.
+- For source files, `.cpp` extensions must be used.
+- Code should be formatted using `clang-format`, with the provided
+  `.clang-format` file. If part of the code needs to be formatted manually for
+  some reasons, `// clang-format off` and `// clang-format on` comments may be
+  used.
 
 [^1]: Internal functions are functions that are not part of the public C++
       API. They are not declared in the header files, or they are declared
@@ -156,13 +113,13 @@ The remaining rules are the same as the Google C++ Style Guide.
 
 #### Python
 
-All code written in Python SHOULD follow the
+All code written in Python should follow the
 [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide.
 
 ### Pull requests
 
 Once you've finished working on an issue, please create a new pull request with
-the following REQUIRED information:
+the following required information:
 
 - Code review checklist (will be automatically generated from the
   [PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) file).

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -10,26 +10,35 @@ cpp_test=false
 py_test=false
 output_args=()
 output=''
+jobs="$(nproc)"
 
-while getopts ':-:' opt; do
+while getopts ':j:-:' opt; do
 	case "$opt" in
-	-) ;;
-	*) exit 1 ;;
-	esac
-
-	case "$OPTARG" in
-	cpp) cpp_test=true ;;
-	python) py_test=true ;;
-	html)
-		output_args=(--html-details)
-		output="coverage/html/index.html"
+	j) jobs="$OPTARG" ;;
+	-)
+		case "$OPTARG" in
+		cpp) cpp_test=true ;;
+		python) py_test=true ;;
+		html)
+			output_args=(--html-details)
+			output="coverage/html/index.html"
+			;;
+		json)
+			output_args=(--coveralls)
+			output="coverage/json/coverage.json"
+			;;
+		*)
+			echo >&2 "Unknown option: --$OPTARG"
+			exit 1
+			;;
+		esac
 		;;
-	json)
-		output_args=(--coveralls)
-		output="coverage/json/coverage.json"
+	:)
+		echo >&2 "Option -$OPTARG requires an argument"
+		exit 1
 		;;
 	*)
-		echo >&2 "Unknown option: --$OPTARG"
+		echo >&2 "Unknown option: -$OPTARG"
 		exit 1
 		;;
 	esac
@@ -47,13 +56,13 @@ cd "$prj_root"
 
 if [[ $cpp_test = true ]]; then
 	pushd "$build_dir"
-	ctest -"j$(nproc)" --output-on-failure
+	ctest -"j$jobs" --output-on-failure
 	popd
 fi
 
 if [[ $py_test = true ]]; then
-	pytest -v -"n$(nproc)" python/test
-	cmake --build "$build_dir" --target NuriPythonDoctest -"j$(nproc)"
+	pytest -v -"n$jobs" python/test
+	cmake --build "$build_dir" --target NuriPythonDoctest -"j$jobs"
 fi
 
 if [[ -n $output ]]; then

--- a/scripts/run_clang_tools.sh
+++ b/scripts/run_clang_tools.sh
@@ -37,22 +37,23 @@ done
 
 shift $((OPTIND - 1))
 
+if [[ $# -eq 0 ]]; then
+	tidy_paths=(include src python/include python/src)
+	format_paths=("${tidy_paths[@]}" test)
+else
+	tidy_paths=("$@")
+	format_paths=("$@")
+fi
+
 tmpd="$(mktemp -d)"
 trap 'rm -rf "$tmpd"' INT TERM EXIT
 
-if [[ $# -eq 0 ]]; then
-	find include src python/include python/src \
-		\( -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' \) -print0 \
-		>"$tmpd/tidy-checks"
-
-	cp "$tmpd/tidy-checks" "$tmpd/format-checks"
-
-	find test \( -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' \) -print0 \
-		>>"$tmpd/format-checks"
-else
-	printf '%s\0' "$@" >"$tmpd/tidy-checks"
-	cp "$tmpd/tidy-checks" "$tmpd/format-checks"
-fi
+find "${tidy_paths[@]}" \
+	\( -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' \) \
+	-print0 >"$tmpd/tidy-checks"
+find "${format_paths[@]}" \
+	\( -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' \) \
+	-print0 >"$tmpd/format-checks"
 
 xargs -0 -P"$nproc" -n1 clang-format "${cf_args[@]}" <"$tmpd/format-checks"
 xargs -0 -P"$nproc" -n1 clang-tidy -p build "${ct_args[@]}" <"$tmpd/tidy-checks"

--- a/scripts/run_clang_tools.sh
+++ b/scripts/run_clang_tools.sh
@@ -17,7 +17,15 @@ if [[ ! -d build ]]; then
 fi
 
 cf_args=("-i")
+nproc="$(nproc)"
+
 ct_args=(--warnings-as-errors='*')
+if command -v gcc &>/dev/null; then
+	ct_args+=(
+		--extra-arg="--gcc-install-dir=$(dirname "$(gcc -print-libgcc-file-name)")"
+	)
+fi
+
 while getopts 'cj:x:' opt; do
 	case "$opt" in
 	c) cf_args=(-n --Werror) ;;
@@ -46,5 +54,5 @@ else
 	cp "$tmpd/tidy-checks" "$tmpd/format-checks"
 fi
 
-xargs -0 -P"${nproc-0}" -n1 clang-format "${cf_args[@]}" <"$tmpd/format-checks"
-xargs -0 -P"${nproc-0}" -n1 clang-tidy -p build "${ct_args[@]}" <"$tmpd/tidy-checks"
+xargs -0 -P"$nproc" -n1 clang-format "${cf_args[@]}" <"$tmpd/format-checks"
+xargs -0 -P"$nproc" -n1 clang-tidy -p build "${ct_args[@]}" <"$tmpd/tidy-checks"


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Do all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #...

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and dev-tooling only; CMake default for optional targets changes only when `NURI_BUILD_DEV_MODE=ON`, which is opt-in at configure time.
> 
> **Overview**
> Adds **agent-oriented onboarding** via new `AGENTS.md` (build variants, dev commands, coding rules) and `CLAUDE.md` that points to it, plus a **sanitizer-build** skill documenting `clang++` and env vars for the `sanitizers` CMake variant.
> 
> **CMake** gains `NURI_BUILD_DEV_MODE` (default off); when on, it enables docs, Python docs/doctest, and Python stubs by default—matching the configure recipe in `AGENTS.md`.
> 
> **CONTRIBUTING.md** is streamlined: less RFC-2119 / lab-specific prose, broader OS notes, clang tool version guidance tied to CI, and removal of inline clone/build/branching sections (those live in `AGENTS.md`).
> 
> **Scripts:** `check_coverage.sh` adds `-j` for parallel tests/builds; `run_clang_tools.sh` defaults parallelism to `nproc`, passes `--gcc-install-dir` to `clang-tidy` when GCC is present, and discovers files with `find` over path lists instead of duplicating file lists in temp files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a408e595b232dd1bdc89744134ea890d32613351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->