### PR TITLE
build: link and ship abseil as shared library

### DIFF
--- a/.github/workflows/_wheel-build.yaml
+++ b/.github/workflows/_wheel-build.yaml
@@ -71,7 +71,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ inputs.python }}
           CIBW_ARCHS: "all"
-          SKBUILD_CMAKE_ARGS: "-DCMAKE_INSTALL_RPATH=${{ steps.resolve.outputs.ldpath }};-DNURI_BUILD_LIB=OFF;-DNURI_PREBUILT_ABSL=ON"
+          SKBUILD_CMAKE_ARGS: "-DCMAKE_INSTALL_RPATH=${{ steps.resolve.outputs.ldpath }};-DNURI_BUILD_LIB=OFF"
 
       - name: Upload wheels
         uses: actions/upload-artifact@v7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,22 @@ endif()
 if(NURI_BUILD_LIB OR NURI_BUILD_PYTHON OR BUILD_TESTING)
   find_or_fetch_abseil()
 
+  # When we downloaded a prebuilt (imported) abseil, ship it beside libnuri so
+  # the C++ install / release tarball is self-contained: consumers resolve the
+  # runtime via RPATH, and downstream find_package(absl) uses the bundled cmake
+  # config. Imported abseil has no install rules of its own. Skipped under
+  # SKBUILD (wheels consume this tarball's abseil via find_package instead).
+  #
+  # The tarball is already an install tree; copy it wholesale. This is declared
+  # before add_subdirectory(src), so abseil (including its lib->lib64 symlink)
+  # installs first and libnuri then lands in the same libdir through it -- no
+  # pre-existing dir to clash with, and abseil's cmake config stays valid.
+  # Order is guaranteed: CMP0082 is NEW (cmake_minimum_required 3.16 >= 3.14),
+  # so install rules run in declaration order; do not move this after src.
+  if(NURI_ABSL_PREBUILT_DIR AND NOT SKBUILD)
+    install(DIRECTORY "${NURI_ABSL_PREBUILT_DIR}/" DESTINATION ".")
+  endif()
+
   find_or_add_package(
     NAME Eigen3
     MIN_VERSION 3.4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,8 +176,7 @@ if(NURI_BUILD_LIB OR NURI_BUILD_PYTHON OR BUILD_TESTING)
   # When we downloaded a prebuilt (imported) abseil, ship it beside libnuri so
   # the C++ install / release tarball is self-contained: consumers resolve the
   # runtime via RPATH, and downstream find_package(absl) uses the bundled cmake
-  # config. Imported abseil has no install rules of its own. Skipped under
-  # SKBUILD (wheels consume this tarball's abseil via find_package instead).
+  # config. Imported abseil has no install rules of its own.
   #
   # The tarball is already an install tree; copy it wholesale. This is declared
   # before add_subdirectory(src), so abseil (including its lib->lib64 symlink)
@@ -185,7 +184,7 @@ if(NURI_BUILD_LIB OR NURI_BUILD_PYTHON OR BUILD_TESTING)
   # pre-existing dir to clash with, and abseil's cmake config stays valid.
   # Order is guaranteed: CMP0082 is NEW (cmake_minimum_required 3.16 >= 3.14),
   # so install rules run in declaration order; do not move this after src.
-  if(NURI_ABSL_PREBUILT_DIR AND NOT SKBUILD)
+  if(NURI_ABSL_PREBUILT_DIR)
     install(DIRECTORY "${NURI_ABSL_PREBUILT_DIR}/" DESTINATION ".")
   endif()
 

--- a/cmake/NuriKitPythonUtils.cmake
+++ b/cmake/NuriKitPythonUtils.cmake
@@ -80,10 +80,14 @@ function(nuri_python_add_module name)
       "${CMAKE_CURRENT_LIST_DIR}/nuri/${subdir}"
       "${CMAKE_CURRENT_LIST_DIR}/nuri/"
     )
+    set(module_rpath
+      "${NURI_RPATH_PREFIX}/${dir_inv}${CMAKE_INSTALL_LIBDIR}"
+      "${NURI_RPATH_PREFIX}/${dir_inv}lib64"
+    )
     set_target_properties(
       "${target_name}"
       PROPERTIES
-      INSTALL_RPATH "${NURI_RPATH_PREFIX}/${dir_inv}${CMAKE_INSTALL_LIBDIR}"
+      INSTALL_RPATH "${module_rpath}"
     )
   endif()
 

--- a/cmake/NuriKitUtils.cmake
+++ b/cmake/NuriKitUtils.cmake
@@ -168,7 +168,7 @@ function(find_or_fetch_abseil)
 
       Fetchcontent_Declare(
         absl
-        URL "https://github.com/jnooree/abseil-cpp/releases/latest/download/libabsl-static-${os_arch}.tar.gz"
+        URL "https://github.com/jnooree/abseil-cpp/releases/latest/download/libabsl-shared-${os_arch}.tar.gz"
       )
       Fetchcontent_MakeAvailable(absl)
 
@@ -204,13 +204,12 @@ function(find_or_fetch_abseil)
     NAME absl
     OPTIONS
     "BUILD_TESTING OFF"
-    "BUILD_SHARED_LIBS OFF"
+    "BUILD_SHARED_LIBS ON"
     "ABSL_ENABLE_INSTALL ON"
     "ABSL_BUILD_TESTING OFF"
     "ABSL_PROPAGATE_CXX_STD ON"
     "ABSL_USE_SYSTEM_INCLUDES ON"
     URL https://github.com/jnooree/abseil-cpp/releases/latest/download/abseil-cpp-latest.tar.gz
-    EXCLUDE_FROM_ALL ON
     SYSTEM ON
   )
 endfunction()

--- a/cmake/NuriKitUtils.cmake
+++ b/cmake/NuriKitUtils.cmake
@@ -172,6 +172,11 @@ function(find_or_fetch_abseil)
       )
       Fetchcontent_MakeAvailable(absl)
 
+      # The extracted tarball is upstream's `cmake --install` tree; expose it so
+      # the install step can ship it beside libnuri (imported abseil has no
+      # install rules of its own).
+      set(NURI_ABSL_PREBUILT_DIR "${absl_SOURCE_DIR}" PARENT_SCOPE)
+
       set(absl_findpackage_args PATHS "${absl_SOURCE_DIR}" NO_DEFAULT_PATH)
     else()
       set(absl_findpackage_args QUIET)

--- a/cmake/NuriKitUtils.cmake
+++ b/cmake/NuriKitUtils.cmake
@@ -172,11 +172,6 @@ function(find_or_fetch_abseil)
       )
       Fetchcontent_MakeAvailable(absl)
 
-      # The extracted tarball is upstream's `cmake --install` tree; expose it so
-      # the install step can ship it beside libnuri (imported abseil has no
-      # install rules of its own).
-      set(NURI_ABSL_PREBUILT_DIR "${absl_SOURCE_DIR}" PARENT_SCOPE)
-
       set(absl_findpackage_args PATHS "${absl_SOURCE_DIR}" NO_DEFAULT_PATH)
     else()
       set(absl_findpackage_args QUIET)
@@ -188,6 +183,11 @@ function(find_or_fetch_abseil)
       message(STATUS "Found absl ${absl_VERSION}")
       set(absl_FOUND "${absl_FOUND}" PARENT_SCOPE)
       set(absl_VERSION "${absl_VERSION}" PARENT_SCOPE)
+
+      # The extracted tarball is upstream's `cmake --install` tree; expose it so
+      # the install step can ship it beside libnuri (imported abseil has no
+      # install rules of its own).
+      set(NURI_ABSL_PREBUILT_DIR "${absl_SOURCE_DIR}" PARENT_SCOPE)
 
       if(NURI_PREBUILT_ABSL AND CMAKE_SYSTEM_NAME MATCHES Linux)
         set(ABSL_USES_OLD_ABI ON PARENT_SCOPE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,6 +102,14 @@ target_link_libraries(NuriExe PRIVATE NuriLib absl::log_initialize)
 set_target_properties(NuriExe PROPERTIES OUTPUT_NAME nuri)
 
 if(NURI_INSTALL_RPATH)
+  # DT_RUNPATH is not transitive, so consumers' RPATH cannot resolve libnuri's
+  # own shared abseil dependencies; libnuri must locate its siblings itself.
+  set_target_properties(
+    NuriLib
+    PROPERTIES
+    INSTALL_RPATH "${NURI_RPATH_PREFIX}"
+  )
+
   set_target_properties(
     NuriExe
     PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,13 +107,17 @@ if(NURI_INSTALL_RPATH)
   set_target_properties(
     NuriLib
     PROPERTIES
-    INSTALL_RPATH "${NURI_RPATH_PREFIX}"
+    INSTALL_RPATH "${NURI_RPATH_PREFIX};${NURI_RPATH_PREFIX}/../lib64"
   )
 
+  set(exe_rpath
+    "${NURI_RPATH_PREFIX}/../${CMAKE_INSTALL_LIBDIR}"
+    "${NURI_RPATH_PREFIX}/../lib64"
+  )
   set_target_properties(
     NuriExe
     PROPERTIES
-    INSTALL_RPATH "${NURI_RPATH_PREFIX}/../${CMAKE_INSTALL_LIBDIR}"
+    INSTALL_RPATH "${exe_rpath}"
   )
 endif()
 


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Do all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #...

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how native binaries locate and ship shared Abseil at install and wheel time; misconfigured RPATH or bundling could break runtime loading for C++ consumers and Python wheels.
> 
> **Overview**
> Switches Abseil from **static** to **shared** linking: prebuilt artifacts use `libabsl-shared` tarballs, and the CPM fallback builds with `BUILD_SHARED_LIBS ON` (no longer `EXCLUDE_FROM_ALL`).
> 
> When **prebuilt Abseil** is used, the extracted install tree is **bundled into the C++ install/release** via `install(DIRECTORY …)` so tarballs stay self-contained and `find_package(absl)` can use the shipped CMake config.
> 
> **RPATH** is expanded so `libnuri`, the `nuri` executable, and Python extension modules can resolve shared Abseil next to `lib` / `lib64` (including `$ORIGIN/../lib64` on `NuriLib`, since runpath is not transitive). Top-level CMake defaults `CMAKE_INSTALL_RPATH_USE_LINK_PATH` to **OFF**; scikit-build, Read the Docs, and wheel CI are adjusted accordingly (wheel builds drop explicit `NURI_PREBUILT_ABSL=ON` when linking against a prebuilt `libnuri` artifact).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c17c17df017fd2f0aa5c05bc08f6e3bff375a13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->