### PR TITLE
 refactor(python/fmt): move CIF bindings into `nuri.fmt.cif` submodule 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ option(NURI_BUILD_FUZZING "Enable fuzzing build" OFF)
 option(NURI_BUILD_BENCHMARK "Enable benchmark build" OFF)
 
 option(NURI_BUILD_PYTHON_STUBS "Build python stub files" ${NURI_BUILD_DEV_MODE})
-option(NURI_PREBUILT_ABSL "Download prebuilt abseil binary" OFF)
+option(NURI_PREBUILT_ABSL "Download prebuilt abseil binary" ${NURI_BUILD_DEV_MODE})
 set(NURI_FORCE_VERSION "" CACHE STRING "Set NuriKit version to this value")
 mark_as_advanced(
   NURI_BUILD_PYTHON_STUBS

--- a/python/docs/nuri.fmt.rst
+++ b/python/docs/nuri.fmt.rst
@@ -6,8 +6,8 @@ nuri.fmt
 ========
 
 .. automodule:: nuri.fmt
-    :exclude-members: MoleculeReader, CifBlock, CifFrame, CifTable, CifValue,
-        readfile, readstring, to_smiles, to_mol2, to_sdf, to_pdb
+    :exclude-members: MoleculeReader, readfile, readstring, to_smiles, to_mol2,
+        to_sdf, to_pdb
 
     .. autoclass:: MoleculeReader
 
@@ -19,19 +19,30 @@ nuri.fmt
 
             Returns the next molecule.
 
-    .. autoclass:: CifBlock
+------------------
+CIF Format Support
+------------------
+
+.. code-block:: python
+
+   from nuri.fmt import cif
+
+.. automodule:: nuri.fmt.cif
+    :exclude-members: Block, Frame, Table, Value
+
+    .. autoclass:: Block
 
         .. automethod:: __init__
 
-    .. autoclass:: CifFrame
+    .. autoclass:: Frame
 
         .. automethod:: __init__
 
-    .. autoclass:: CifTable
+    .. autoclass:: Table
 
         .. automethod:: __init__
 
-    .. autoclass:: CifValue
+    .. autoclass:: Value
 
         .. automethod:: __init__
 

--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -55,7 +55,7 @@ nuri_python_add_module(fmt
   nuri/fmt/fmt_module.cpp
   nuri/fmt/cif.cpp
   nuri/fmt/pdb.cpp
-  OUTPUT_STUBS nuri/fmt/__init__.pyi nuri/fmt/pdb.pyi
+  OUTPUT_STUBS nuri/fmt/__init__.pyi nuri/fmt/cif.pyi nuri/fmt/pdb.pyi
 )
 target_link_libraries("${NURI_PYTHON_MODULE_TARGET}"
   PRIVATE absl::span

--- a/python/src/nuri/fmt/cif.cpp
+++ b/python/src/nuri/fmt/cif.cpp
@@ -610,6 +610,14 @@ Load this frame as a list of molecules.
 :return: A list of molecules loaded from the frame.
 )doc");
 
+  // Compat shims; might be removed in a future release.
+  // Need to bind as free functions additionally, otherwise stubgen will not
+  // generate the correct signatures.
+  m.def("_frame_as_ddl2_dict", cif_ddl2_frame_as_dict, py::arg("frame"),
+        R"doc(Deprecated alias for :meth:`Frame.as_ddl2_dict`.)doc");
+  m.def("_frame_as_mols", mmcif_load_cif_frame, py::arg("frame"),
+        R"doc(Deprecated alias for :meth:`Frame.as_mols`.)doc");
+
   bind_opaque_vector<internal::CifFrame, PyCifFrame, wrap_cif_frame>(
       m, "_FrameList", "_FrameList index out of range");
 

--- a/python/src/nuri/fmt/cif.cpp
+++ b/python/src/nuri/fmt/cif.cpp
@@ -198,9 +198,7 @@ class PyCifTableIterator
 public:
   using Parent::Parent;
 
-  static auto bind(py::module &m) {
-    return Parent::bind(m, "_CifTableIterator");
-  }
+  static auto bind(py::module &m) { return Parent::bind(m, "_TableIterator"); }
 
 private:
   friend Parent;
@@ -235,7 +233,7 @@ public:
 
   pyt::List<pyt::Optional<py::str>> get(int row) const {
     row = py_check_index(static_cast<int>(table().size()), row,
-                         "CifTable row index out of range");
+                         "CIF table row index out of range");
     return cif_table_row(table(), row);
   }
 
@@ -260,7 +258,7 @@ public:
   using Parent::PyIterator;
 
   static auto bind(py::module &m) {
-    return Parent::bind(m, "_CifFrameIterator", kReturnsSubobject);
+    return Parent::bind(m, "_FrameIterator", kReturnsSubobject);
   }
 
 private:
@@ -304,7 +302,7 @@ public:
 
   PyCifTable get(int idx) const {
     idx = py_check_index(static_cast<int>(frame().size()), idx,
-                         "CifFrame table index out of range");
+                         "CIF frame table index out of range");
     return PyCifTable(frame()[idx]);
   }
 
@@ -528,20 +526,20 @@ py::str write_cif_from_frame(const PyCifFrame &frame, bool align) {
 }  // namespace
 
 void bind_cif(py::module &m) {
-  // Register CifValue first so it resolves to its Python name (not the C++ type
-  // name) in the CifTable cell annotation below.
-  py::class_<internal::CifValue> cv(m, "CifValue", R"doc(
-An explicit CIF value, for use as a :class:`CifTable` cell.
+  // Register Value first so it resolves to its Python name (not the C++ type
+  // name) in the Table cell annotation below.
+  py::class_<internal::CifValue> cv(m, "Value", R"doc(
+An explicit CIF value, for use as a :class:`Table` cell.
 
 Most cells can be given as plain Python objects (:class:`str`, :class:`int`,
-:class:`bool`, :class:`float`, or ``None``); construct a :class:`CifValue`
+:class:`bool`, :class:`float`, or ``None``); construct a :class:`Value`
 directly only when you need control over the formatting. The constructor is
 overloaded on the type of ``value``.
 )doc");
 
   PyCifTableIterator::bind(m);
 
-  py::class_<PyCifTable>(m, "CifTable")
+  py::class_<PyCifTable>(m, "Table")
       .def(py::init<const CifKeys &, const CifRows &, std::string_view,
                     const CifFormatKwargs &>(),
            py::arg("keys"), py::arg("rows"), py::arg("category") = "",
@@ -552,17 +550,17 @@ Construct a CIF table from column keys and rows of values.
   ``["atom_site.id", "atom_site.type_symbol"]``); a ``_`` is prepended to each.
 :param rows: The rows of the table. Each row must have exactly ``len(keys)``
   cells. A cell may be a :class:`str`, :class:`int`, :class:`bool`,
-  :class:`float`, ``None``, or a :class:`CifValue`.
+  :class:`float`, ``None``, or a :class:`Value`.
 :param category: Optional DDL2 category. When non-empty, each key is formed as
   ``_<category>.<key>``, so ``keys`` may list just the attribute names (e.g.
   ``category="atom_site", keys=["id", "type_symbol"]``). Empty (the default)
   leaves keys as given.
 :param formatter_kwargs: Optional per-column formatting options, mapping a
   column key (as given in ``keys``) to the keyword arguments forwarded to the
-  :class:`CifValue` constructor when a plain scalar (or ``None``) cell in that
+  :class:`Value` constructor when a plain scalar (or ``None``) cell in that
   column is converted. Each keyword applies only to cells of its matching type
-  (see :class:`CifValue`); columns not listed use the defaults. Explicit
-  :class:`CifValue` cells are unaffected.
+  (see :class:`Value`); columns not listed use the defaults. Explicit
+  :class:`Value` cells are unaffected.
 :raises ValueError: If a row length differs from the number of keys, a key is
   not a valid or unique CIF data name, or ``formatter_kwargs`` names an unknown
   key or an invalid option.
@@ -581,7 +579,7 @@ Construct a CIF table from column keys and rows of values.
 
   PyCifFrameIterator::bind(m);
 
-  py::class_<PyCifFrame> cf(m, "CifFrame");
+  py::class_<PyCifFrame> cf(m, "Frame");
   cf.def(py::init<std::string, const CifTables &>(), py::arg("name"),
          py::arg("tables"), R"doc(
 Construct a CIF frame (data block body or save frame) from tables.
@@ -600,11 +598,22 @@ Search for the first table containing a column starting with the given prefix.
 :return: The first table containing the given prefix, or None if not found.
 )doc");
   cf.def_property_readonly("name", &PyCifFrame::name);
+  cf.def("as_ddl2_dict", cif_ddl2_frame_as_dict, R"doc(
+Convert this DDL2 (mmCIF) frame to a dictionary of lists of dictionaries.
+
+:return: A dictionary of lists of dictionaries, where the keys are the parent
+  keys and the values are the rows of the table.
+)doc");
+  cf.def("as_mols", mmcif_load_cif_frame, R"doc(
+Load this frame as a list of molecules.
+
+:return: A list of molecules loaded from the frame.
+)doc");
 
   bind_opaque_vector<internal::CifFrame, PyCifFrame, wrap_cif_frame>(
-      m, "_CifFrameList", "_CifFrameList index out of range");
+      m, "_FrameList", "_FrameList index out of range");
 
-  py::class_<PyCifBlock> cb(m, "CifBlock");
+  py::class_<PyCifBlock> cb(m, "Block");
   cb.def(py::init(&build_cif_block), py::arg("data"),
          py::arg("save") = py::tuple(), R"doc(
 Construct a CIF block.
@@ -618,30 +627,15 @@ Construct a CIF block.
       .def_property_readonly("save_frames", &PyCifBlock::save_frames);
   def_property_readonly_subobject(cb, "data", &PyCifBlock::data);
 
-  py::class_<PyCifParser>(m, "_CifParser")
+  py::class_<PyCifParser>(m, "_Parser")
       .def("__iter__", pass_through<PyCifParser>)
       .def("__next__", &PyCifParser::next);
 
-  m.def("read_cif", PyCifParser::from_file, py::arg("path"), R"doc(
+  m.def("read_blocks", PyCifParser::from_file, py::arg("path"), R"doc(
 Create a parser object from a CIF file path.
 
 :param path: The path to the CIF file.
 :return: An iterator over the blocks in the file.
-)doc")
-      .def("cif_ddl2_frame_as_dict", cif_ddl2_frame_as_dict, py::arg("frame"),
-           R"doc(
-Convert a CIF frame to a dictionary of lists of dictionaries.
-
-:param frame: The CIF frame to convert.
-:return: A dictionary of lists of dictionaries, where the keys are the parent
-  keys and the values are the rows of the table.
-)doc")
-      .def("mmcif_load_frame", mmcif_load_cif_frame, py::arg("frame"),
-           R"doc(
-Load a CIF frame as a list of molecules.
-
-:param frame: The CIF frame to load.
-:return: A list of molecules loaded from the frame.
 )doc");
 
   cv.def(py::init([](std::string_view value, bool raw) {
@@ -695,22 +689,22 @@ Store a null CIF value.
 :raises ValueError: If ``null_token`` is not ``"?"`` or ``"."``.
 )doc");
 
-  m.def("write_cif", write_cif_from_frame, py::arg("frame"),
+  m.def("write", write_cif_from_frame, py::arg("frame"),
         py::arg("align") = false, R"doc(
 Serialize a CIF frame to a CIF 1.1 string.
 
-:param frame: The :class:`CifFrame` to serialize, written as a ``data_`` block.
+:param frame: The :class:`Frame` to serialize, written as a ``data_`` block.
   Both freshly constructed and parsed objects are accepted.
 :param align: Whether to pad the columns of ``loop_`` tables so that values
   line up. Defaults to ``False``.
 :return: The serialized CIF string.
 :raises ValueError: If a value cannot be represented in CIF 1.1.
 )doc")
-      .def("write_cif", write_cif_from_block, py::arg("block"),
+      .def("write", write_cif_from_block, py::arg("block"),
            py::arg("align") = false, R"doc(
 Serialize a CIF block to a CIF 1.1 string.
 
-:param block: The :class:`CifBlock` to serialize.
+:param block: The :class:`Block` to serialize.
 :param align: Whether to pad the columns of ``loop_`` tables so that values
   line up. Defaults to ``False``.
 :return: The serialized CIF string.
@@ -724,9 +718,9 @@ Serialize a CIF block to a CIF 1.1 string.
   is **not** valid CIF 1.1; a warning is logged in that case.
 
 >>> import nuri
->>> table = nuri.fmt.CifTable(["x.a", "x.b"], [[1, "two words"], [None, nuri.fmt.CifValue(None, null_token=".")]])
->>> block = nuri.fmt.CifBlock(nuri.fmt.CifFrame("demo", [table]))
->>> print(nuri.fmt.write_cif(block))
+>>> table = nuri.fmt.cif.Table(["x.a", "x.b"], [[1, "two words"], [None, nuri.fmt.cif.Value(None, null_token=".")]])
+>>> block = nuri.fmt.cif.Block(nuri.fmt.cif.Frame("demo", [table]))
+>>> print(nuri.fmt.cif.write(block))
 data_demo
 loop_
 _x.a

--- a/python/src/nuri/fmt/fmt_module.cpp
+++ b/python/src/nuri/fmt/fmt_module.cpp
@@ -298,8 +298,8 @@ Convert a molecule to PDB string.
   m.attr("CifBlock") = cif.attr("Block");
   m.attr("read_cif") = cif.attr("read_blocks");
   m.attr("write_cif") = cif.attr("write");
-  m.attr("cif_ddl2_frame_as_dict") = cif.attr("Frame").attr("as_ddl2_dict");
-  m.attr("mmcif_load_frame") = cif.attr("Frame").attr("as_mols");
+  m.attr("cif_ddl2_frame_as_dict") = cif.attr("_frame_as_ddl2_dict");
+  m.attr("mmcif_load_frame") = cif.attr("_frame_as_mols");
 
   py::module_ pdb =
       m.def_submodule("pdb", "PDB format-specific handlers and utilities.");

--- a/python/src/nuri/fmt/fmt_module.cpp
+++ b/python/src/nuri/fmt/fmt_module.cpp
@@ -287,7 +287,19 @@ Convert a molecule to PDB string.
   will not produce a valid PDB file.
 )doc");
 
-  bind_cif(m);
+  py::module_ cif =
+      m.def_submodule("cif", "CIF format-specific handlers and utilities.");
+  bind_cif(cif);
+
+  // Backward-compatible aliases: CIF used to live directly in nuri.fmt.
+  m.attr("CifValue") = cif.attr("Value");
+  m.attr("CifTable") = cif.attr("Table");
+  m.attr("CifFrame") = cif.attr("Frame");
+  m.attr("CifBlock") = cif.attr("Block");
+  m.attr("read_cif") = cif.attr("read_blocks");
+  m.attr("write_cif") = cif.attr("write");
+  m.attr("cif_ddl2_frame_as_dict") = cif.attr("Frame").attr("as_ddl2_dict");
+  m.attr("mmcif_load_frame") = cif.attr("Frame").attr("as_mols");
 
   py::module_ pdb =
       m.def_submodule("pdb", "PDB format-specific handlers and utilities.");

--- a/python/test/fmt/cif_compat_test.py
+++ b/python/test/fmt/cif_compat_test.py
@@ -1,0 +1,51 @@
+#
+# Project NuriKit - Copyright 2025 SNU Compbio Lab.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""CIF moved from nuri.fmt into the nuri.fmt.cif submodule; the old top-level
+names must keep working."""
+
+from pathlib import Path
+
+import nuri.fmt as fmt
+from nuri.fmt import cif
+
+
+def test_class_aliases_are_identical():
+    assert fmt.CifValue is cif.Value
+    assert fmt.CifTable is cif.Table
+    assert fmt.CifFrame is cif.Frame
+    assert fmt.CifBlock is cif.Block
+
+
+def test_function_aliases_are_identical():
+    assert fmt.read_cif is cif.read_blocks
+    assert fmt.write_cif is cif.write
+
+
+def test_old_names_importable():
+    from nuri.fmt import (  # noqa: F401
+        CifBlock,
+        CifFrame,
+        CifTable,
+        CifValue,
+        cif_ddl2_frame_as_dict,
+        mmcif_load_frame,
+        read_cif,
+        write_cif,
+    )
+
+
+def test_method_backed_compat_functions():
+    frame = cif.Frame("d", [cif.Table(["a.x"], [["1"]])])
+
+    assert fmt.cif_ddl2_frame_as_dict(frame) == frame.as_ddl2_dict()
+    assert len(fmt.mmcif_load_frame(frame)) == len(frame.as_mols())
+
+
+def test_old_api_round_trips(test_data: Path):
+    block = next(fmt.read_cif(test_data / "1a8o.cif"))
+    text = fmt.write_cif(block)
+    assert text.startswith("data_1A8O")
+    assert fmt.cif_ddl2_frame_as_dict(block.data)["entry"][0]["id"] == "1A8O"

--- a/python/test/fmt/cif_test.py
+++ b/python/test/fmt/cif_test.py
@@ -8,21 +8,20 @@ from pathlib import Path
 
 import pytest
 
-from nuri.fmt import (
-    CifBlock,
-    CifFrame,
-    CifTable,
-    CifValue,
-    cif_ddl2_frame_as_dict,
-    read_cif,
-    write_cif,
+from nuri.fmt.cif import (
+    Block,
+    Frame,
+    Table,
+    Value,
+    read_blocks,
+    write,
 )
 
 
 def test_read_cif(test_data: Path):
     cif = test_data / "1a8o.cif"
 
-    blocks = list(read_cif(cif))
+    blocks = list(read_blocks(cif))
     assert len(blocks) == 1
 
     block = blocks[0]
@@ -91,18 +90,18 @@ def test_read_cif(test_data: Path):
 
 
 def test_read_cif_temporary(test_data: Path):
-    data = next(read_cif(test_data / "1a8o.cif")).data
+    data = next(read_blocks(test_data / "1a8o.cif")).data
     assert data.name == "1A8O"
 
 
 def test_convert_ddl2_cif(test_data: Path):
     cif = test_data / "1a8o.cif"
 
-    blocks = list(read_cif(cif))
+    blocks = list(read_blocks(cif))
     assert len(blocks) == 1
     frame = blocks[0].data
 
-    ddl = cif_ddl2_frame_as_dict(frame)
+    ddl = frame.as_ddl2_dict()
 
     assert ddl["entry"][0]["id"] == "1A8O"
 
@@ -114,21 +113,21 @@ def test_convert_ddl2_cif(test_data: Path):
 
 
 def _read_one(path: Path):
-    return next(read_cif(path))
+    return next(read_blocks(path))
 
 
 def test_write_cif_build_roundtrip(tmp_path: Path):
-    table = CifTable(
+    table = Table(
         ["atom.id", "atom.name", "atom.alt"],
         [
-            ["1", "atom with space", CifValue(None)],
+            ["1", "atom with space", Value(None)],
             ["2", "N", None],
         ],
     )
-    entry = CifTable(["entry.id"], [["TEST"]])
-    block = CifBlock(CifFrame("test", [entry, table]))
+    entry = Table(["entry.id"], [["TEST"]])
+    block = Block(Frame("test", [entry, table]))
 
-    text = write_cif(block)
+    text = write(block)
     assert "_atom.id" in text  # leading underscore is prepended
 
     out = tmp_path / "out.cif"
@@ -137,7 +136,7 @@ def test_write_cif_build_roundtrip(tmp_path: Path):
     back = _read_one(out)
     assert back.name == "test"
 
-    ddl = cif_ddl2_frame_as_dict(back.data)
+    ddl = back.data.as_ddl2_dict()
     assert ddl["entry"][0]["id"] == "TEST"
 
     atoms = ddl["atom"]
@@ -149,34 +148,34 @@ def test_write_cif_build_roundtrip(tmp_path: Path):
 
 
 def test_write_cif_none_defaults_to_unknown():
-    table = CifTable(
+    table = Table(
         ["a.x", "a.y"],
         [[None, None]],
         formatter_kwargs={"a.y": {"null_token": "."}},
     )
-    text = write_cif(CifBlock(CifFrame("d", [table])))
+    text = write(Block(Frame("d", [table])))
     assert "_a.x ?" in text  # x -> unknown (default)
     assert "_a.y ." in text  # y -> inapplicable
 
-    default = CifTable(["a.x"], [[None]])
-    text = write_cif(CifBlock(CifFrame("d", [default])))
+    default = Table(["a.x"], [[None]])
+    text = write(Block(Frame("d", [default])))
     assert "_a.x ?" in text  # None defaults to unknown
 
 
 def test_write_cif_typed_and_mixed_cells():
-    table = CifTable(
+    table = Table(
         ["v.i", "v.f", "v.b", "v.n"],
         [
             [
                 7,
-                CifValue(1.5, precision=3),
+                Value(1.5, precision=3),
                 True,
-                CifValue(None, null_token="."),
+                Value(None, null_token="."),
             ],
-            [CifValue(3, width=4), 2.5, False, CifValue(None)],
+            [Value(3, width=4), 2.5, False, Value(None)],
         ],
     )
-    text = write_cif(CifBlock(CifFrame("d", [table])), align=True)
+    text = write(Block(Frame("d", [table])), align=True)
     assert "7" in text
     assert "1.500" in text
     assert "0003" in text
@@ -189,23 +188,23 @@ def test_write_cif_typed_and_mixed_cells():
 def test_cif_value_string_vs_raw():
     # A numeric-looking str is quoted (kept a string); raw keeps it a bare
     # generic literal (e.g. a standard-uncertainty token).
-    table = CifTable(
+    table = Table(
         ["v.s", "v.r"],
-        [["1.234(5)", CifValue("1.234(5)", raw=True)]],
+        [["1.234(5)", Value("1.234(5)", raw=True)]],
     )
-    text = write_cif(CifBlock(CifFrame("d", [table])))
+    text = write(Block(Frame("d", [table])))
     assert "_v.s '1.234(5)'" in text
     assert "_v.r 1.234(5)" in text
 
 
 def test_cif_value_bad_type():
     with pytest.raises(TypeError):
-        CifValue(["not", "scalar"])
+        Value(["not", "scalar"])
 
 
 def test_write_cif_frame(tmp_path: Path):
-    frame = CifFrame("f", [CifTable(["a.x"], [["1"]])])
-    text = write_cif(frame)
+    frame = Frame("f", [Table(["a.x"], [["1"]])])
+    text = write(frame)
     assert text.startswith("data_f")
 
     out = tmp_path / "frame.cif"
@@ -214,37 +213,35 @@ def test_write_cif_frame(tmp_path: Path):
 
 
 def test_cif_block_bad_save_frames():
-    data = CifFrame("d", [CifTable(["a.x"], [["1"]])])
-    s1 = CifFrame("s", [CifTable(["s.y"], [["2"]])])
-    s2 = CifFrame("s", [CifTable(["s.z"], [["3"]])])
+    data = Frame("d", [Table(["a.x"], [["1"]])])
+    s1 = Frame("s", [Table(["s.y"], [["2"]])])
+    s2 = Frame("s", [Table(["s.z"], [["3"]])])
     with pytest.raises(ValueError, match="Duplicate save frame"):
-        CifBlock(data, [s1, s2])
+        Block(data, [s1, s2])
 
-    unnamed = CifFrame("", [CifTable(["s.y"], [["2"]])])
+    unnamed = Frame("", [Table(["s.y"], [["2"]])])
     with pytest.raises(ValueError, match="empty name"):
-        CifBlock(data, [unnamed])
+        Block(data, [unnamed])
 
 
 def test_write_cif_1a8o_roundtrip(test_data: Path, tmp_path: Path):
     original = _read_one(test_data / "1a8o.cif")
-    text = write_cif(original)
+    text = write(original)
 
     out = tmp_path / "1a8o_out.cif"
     out.write_text(text)
     reparsed = _read_one(out)
 
     assert reparsed.name == "1A8O"
-    assert cif_ddl2_frame_as_dict(original.data) == cif_ddl2_frame_as_dict(
-        reparsed.data
-    )
+    assert original.data.as_ddl2_dict() == reparsed.data.as_ddl2_dict()
 
 
 def test_write_cif_align(tmp_path: Path):
-    table = CifTable(["t.a", "t.b"], [[1, "x"], [2000, "y"]])
-    block = CifBlock(CifFrame("x", [table]))
+    table = Table(["t.a", "t.b"], [[1, "x"], [2000, "y"]])
+    block = Block(Frame("x", [table]))
 
-    plain = write_cif(block)
-    aligned = write_cif(block, align=True)
+    plain = write(block)
+    aligned = write(block, align=True)
     assert plain != aligned
     assert "1    x" in aligned
 
@@ -252,24 +249,24 @@ def test_write_cif_align(tmp_path: Path):
     for text in (plain, aligned):
         out = tmp_path / "a.cif"
         out.write_text(text)
-        assert cif_ddl2_frame_as_dict(_read_one(out).data) == expected
+        assert _read_one(out).data.as_ddl2_dict() == expected
 
 
 def test_write_cif_unrepresentable():
-    block = CifBlock(CifFrame("x", [CifTable(["a"], [["line\n;bad"]])]))
+    block = Block(Frame("x", [Table(["a"], [["line\n;bad"]])]))
     with pytest.raises(ValueError, match="';'"):
-        write_cif(block)
+        write(block)
 
 
 def test_write_cif_global_from_parser(tmp_path: Path, caplog):
     src = tmp_path / "global.cif"
     src.write_text("global_\n_max_height 6.3\n\ndata_b\n_location here\n")
 
-    block = next(read_cif(src))
+    block = next(read_blocks(src))
     assert block.is_global  # global_ blocks are only produced by the parser
 
     with caplog.at_level(logging.WARNING, logger="nuri"):
-        text = write_cif(block)
+        text = write(block)
 
     assert text.startswith("global_")
     assert any("STAR" in record.message for record in caplog.records)
@@ -277,48 +274,48 @@ def test_write_cif_global_from_parser(tmp_path: Path, caplog):
 
 def test_cif_table_bad_cell():
     with pytest.raises(TypeError):
-        CifTable(["a"], [[["not", "a", "scalar"]]])
+        Table(["a"], [[["not", "a", "scalar"]]])
 
 
 def test_cif_table_bad_row_length():
     with pytest.raises(ValueError, match="values but the table has"):
-        CifTable(["a", "b"], [["1"]])
+        Table(["a", "b"], [["1"]])
 
 
 def test_cif_table_bad_key():
     # Tables are validated at construction, unlike the C++ core.
     with pytest.raises(ValueError, match="Invalid CIF key"):
-        CifTable(["bad key"], [["1"]])
+        Table(["bad key"], [["1"]])
     with pytest.raises(ValueError, match="Invalid CIF key"):
-        CifTable([""], [["1"]])
+        Table([""], [["1"]])
 
 
 def test_cif_table_duplicate_key():
     with pytest.raises(ValueError, match="Duplicate"):
-        CifTable(["a.x", "a.x"], [["1", "2"]])
+        Table(["a.x", "a.x"], [["1", "2"]])
     with pytest.raises(ValueError, match="Duplicate"):
-        CifTable(["x", "x"], [["1", "2"]], category="a")
+        Table(["x", "x"], [["1", "2"]], category="a")
 
 
 def test_cif_frame_duplicate_key_across_tables():
     with pytest.raises(ValueError, match="Duplicate"):
-        CifFrame("d", [CifTable(["a.x"], [["1"]]), CifTable(["a.x"], [["2"]])])
+        Frame("d", [Table(["a.x"], [["1"]]), Table(["a.x"], [["2"]])])
 
 
 def test_cif_table_category():
-    table = CifTable(["id", "type_symbol"], [["1", "N"]], category="atom_site")
+    table = Table(["id", "type_symbol"], [["1", "N"]], category="atom_site")
     assert table.keys() == ["_atom_site.id", "_atom_site.type_symbol"]
 
-    text = write_cif(CifBlock(CifFrame("d", [table])))
+    text = write(Block(Frame("d", [table])))
     assert "_atom_site.id" in text
     assert "_atom_site.type_symbol" in text
 
     with pytest.raises(ValueError, match="Invalid CIF key"):
-        CifTable(["id"], [["1"]], category="bad category")
+        Table(["id"], [["1"]], category="bad category")
 
 
 def test_cif_table_formatter_kwargs():
-    table = CifTable(
+    table = Table(
         ["v.i", "v.f", "v.s", "v.b"],
         [[3, 2.5, "1.234(5)", True]],
         formatter_kwargs={
@@ -328,7 +325,7 @@ def test_cif_table_formatter_kwargs():
             "v.b": {"short_form": True},
         },
     )
-    text = write_cif(CifBlock(CifFrame("d", [table])))
+    text = write(Block(Frame("d", [table])))
     assert "_v.i 0003" in text
     assert "_v.f 2.500" in text
     assert "_v.s 1.234(5)" in text  # raw -> unquoted
@@ -337,20 +334,20 @@ def test_cif_table_formatter_kwargs():
 
 def test_cif_table_formatter_kwargs_strict():
     with pytest.raises(ValueError, match="Unknown key in formatter_kwargs"):
-        CifTable(["a"], [["1"]], formatter_kwargs={"b": {"raw": True}})
+        Table(["a"], [["1"]], formatter_kwargs={"b": {"raw": True}})
     with pytest.raises(ValueError, match="Unknown formatter option"):
-        CifTable(["a"], [["1"]], formatter_kwargs={"a": {"bogus": True}})
+        Table(["a"], [["1"]], formatter_kwargs={"a": {"bogus": True}})
     with pytest.raises(ValueError, match="null_token"):
-        CifTable(["a"], [[None]], formatter_kwargs={"a": {"null_token": "x"}})
+        Table(["a"], [[None]], formatter_kwargs={"a": {"null_token": "x"}})
     with pytest.raises(ValueError, match="precision must be non-negative"):
-        CifTable(["a"], [[1.5]], formatter_kwargs={"a": {"precision": -1}})
+        Table(["a"], [[1.5]], formatter_kwargs={"a": {"precision": -1}})
 
 
 def test_cif_value_bad_null_token():
     with pytest.raises(ValueError, match="null_token"):
-        CifValue(None, null_token="x")
+        Value(None, null_token="x")
 
 
 def test_write_cif_bad_type():
     with pytest.raises(TypeError):
-        write_cif("not a cif object")
+        write("not a cif object")

--- a/python/test/fmt/mmcif_test.py
+++ b/python/test/fmt/mmcif_test.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import nuri
 from nuri.core import Molecule
-from nuri.fmt import mmcif_load_frame, read_cif
+from nuri.fmt.cif import read_blocks
 
 
 def _validate_3cye_part(mols: List[Molecule]):
@@ -60,6 +60,6 @@ def test_read_mmcif(test_data: Path):
 
 
 def test_load_mmcif_from_frame(test_data: Path):
-    frame = next(read_cif(test_data / "3cye_part.cif")).data
-    mols = mmcif_load_frame(frame)
+    frame = next(read_blocks(test_data / "3cye_part.cif")).data
+    mols = frame.as_mols()
     _validate_3cye_part(mols)


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [ ] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [ ] Have you built the project locally without any warnings and errors?
- [ ] Do all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #...

---

<!-- Start the description of the PR here -->
