### PR TITLE
ci(gha): keep PIP_ONLY_BINARY on macOS 

### DIFF
--- a/.github/scripts/wheel-targets.sh
+++ b/.github/scripts/wheel-targets.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+#
+# Project NuriKit - Copyright 2026 SNU Compbio Lab.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Print the wheel build matrix as a JSON array of {"python": "<pyver>-<os>"}.
+#
+# With MINIMAL=true, emit only the cp38 smoke-test set plus any targets
+# requested via a `[wheel <prefix> ...]` token in the last commit message;
+# each prefix is matched against the full target list. Otherwise emit the
+# full target list.
+
+set -euo pipefail
+
+pyvers=(cp37 cp38 cp39 cp310 cp311 cp312 cp313 cp313t)
+oses=(manylinux_x86_64 macosx_x86_64 macosx_arm64)
+
+targets=()
+for p in "${pyvers[@]}"; do
+	for o in "${oses[@]}"; do
+		# https://github.com/pypa/cibuildwheel/issues/1278
+		if [[ $p = cp37 && $o = macosx_arm64 ]]; then
+			continue
+		fi
+		targets+=("$p-$o")
+	done
+done
+
+selected=("${targets[@]}")
+
+if [[ ${MINIMAL-} = true ]]; then
+	if [[ ${GITHUB_EVENT_NAME-} = pull_request ]]; then
+		msg="$(git log --no-merges --format=%B -n 1 HEAD)"
+	else
+		msg="$(git log --format=%B -n 1 HEAD)"
+	fi
+
+	prefix=(cp38)
+	while read -r -a words; do
+		prefix+=("${words[@]}")
+	done < <(grep -oE '\[wheel[^]]*\]' <<<"$msg" | sed -E 's/\[wheel//g; s/\]//g')
+
+	selected=()
+	for tgt in "${targets[@]}"; do
+		for pfx in "${prefix[@]}"; do
+			if [[ $tgt = "$pfx"* ]]; then
+				selected+=("$tgt")
+				break
+			fi
+		done
+	done
+fi
+
+jq -nc '$ARGS.positional | map({python: .})' --args "${selected[@]}"

--- a/.github/workflows/_wheel-targets.yaml
+++ b/.github/workflows/_wheel-targets.yaml
@@ -1,0 +1,45 @@
+#
+# Project NuriKit - Copyright 2023 SNU Compbio Lab.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: Compute wheel build matrix
+
+on:
+  workflow_call:
+    inputs:
+      minimal:
+        type: boolean
+        description: "Minimal build (only cp38, plus any requested via commit message)"
+        required: false
+        default: false
+    outputs:
+      include:
+        value: ${{ jobs.targets.outputs.include }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  targets:
+    name: Compute wheel targets
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.compute.outputs.include }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Compute targets
+        id: compute
+        run: |
+          include="$(.github/scripts/wheel-targets.sh)"
+          echo "include=$include" >>"$GITHUB_OUTPUT"
+
+          echo "::group::Selected wheel targets"
+          jq -r '.[].python' <<<"$include"
+          echo "::endgroup::"
+        env:
+          MINIMAL: ${{ inputs.minimal }}

--- a/.github/workflows/wheels-matrix.yaml
+++ b/.github/workflows/wheels-matrix.yaml
@@ -24,9 +24,11 @@ on:
       - main
     paths:
       - ".github/scripts/build-lib.sh"
+      - ".github/scripts/wheel-targets.sh"
       - ".github/workflows/wheels-matrix.yaml"
       - ".github/workflows/_base-build.yaml"
       - ".github/workflows/_wheel-build.yaml"
+      - ".github/workflows/_wheel-targets.yaml"
       - "cmake/**"
       - "include/**"
       - "src/**"
@@ -46,39 +48,22 @@ jobs:
     with:
       emulate-version: ${{ inputs.emulate-version }}
 
+  targets:
+    uses: ./.github/workflows/_wheel-targets.yaml
+    with:
+      minimal: ${{ inputs.minimal }}
+
   build-wheels:
-    needs: common
+    needs: [common, targets]
 
     strategy:
       fail-fast: false
       matrix:
-        pyver:
-          - cp37
-          - cp38
-          - cp39
-          - cp310
-          - cp311
-          - cp312
-          - cp313
-          - cp313t
-        os: ["manylinux_x86_64", "macosx_x86_64", "macosx_arm64"]
-        minimal:
-          - ${{ inputs.minimal }}
-        exclude:
-          - pyver: "cp37"
-            os: "macosx_arm64"
-          - minimal: true
-        include:
-          - pyver: "cp38"
-            os: "manylinux_x86_64"
-          - pyver: "cp38"
-            os: "macosx_x86_64"
-          - pyver: "cp38"
-            os: "macosx_arm64"
+        include: ${{ fromJSON(needs.targets.outputs.include) }}
 
     uses: ./.github/workflows/_wheel-build.yaml
     with:
-      python: ${{ matrix.pyver }}-${{ matrix.os }}
+      python: ${{ matrix.python }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/pyproject.toml.in
+++ b/pyproject.toml.in
@@ -122,13 +122,11 @@ cmake -S {project} -B . \
 [tool.cibuildwheel.environment]
 PIP_ONLY_BINARY = "numpy,scipy"
 PIP_PREFER_BINARY = "1"
+MACOSX_DEPLOYMENT_TARGET = "10.15"
 
 [tool.cibuildwheel.linux]
 environment-pass = ["SKBUILD_CMAKE_ARGS", "CMAKE_PREFIX_PATH"]
 before-all = ["ln -sfT /host/home/linuxbrew /home/linuxbrew"]
-
-[tool.cibuildwheel.macos.environment]
-MACOSX_DEPLOYMENT_TARGET = "10.15"
 
 [tool.pytest.ini_options]
 testpaths = ["python/test"]


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [ ] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [ ] Have you built the project locally without any warnings and errors?
- [ ] Do all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #...

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI matrix generation and cibuildwheel environment layout; no runtime library or application code is affected.
> 
> **Overview**
> **Wheel CI matrix** is no longer defined inline in `wheels-matrix.yaml`. A new `wheel-targets.sh` script builds the full Python/OS target list (with the existing cp37/macosx_arm64 skip), and in **minimal** mode narrows builds to cp38 smoke targets plus any extra prefixes from a `[wheel ...]` token in the latest commit message. A reusable `_wheel-targets.yaml` workflow runs that script and feeds `build-wheels` via `matrix.include` / `matrix.python`.
> 
> **cibuildwheel config:** `MACOSX_DEPLOYMENT_TARGET` moves from `[tool.cibuildwheel.macos.environment]` into the shared `[tool.cibuildwheel.environment]` block alongside `PIP_ONLY_BINARY` and `PIP_PREFER_BINARY`, so macOS wheel jobs inherit the same pip binary-only settings instead of a mac-only env section that could drop them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4b72b831122735bc23c4a3363f91acd9f3c1cf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->