### PR TITLE
fix(fmt/cif): handle non-finite floats correctly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,9 @@
 - **Docs** - **Write docs/docstrings only when asked.** C++ is Doxygen (`docs/`),
   Python is Sphinx (`python/docs/`). For Python docstrings, always use
   Sphinx-compatible reST.
-- **Format & lint** - C++ with `scripts/run_clang_tools.sh` (slow, run only when
-  needed). `ruff` and other checks run via `pre-commit`.
+- **Format & lint** - C++ with `scripts/run_clang_tools.sh` (slow; pass
+  `-d [<ref>]` to check only files changed vs `<ref>`, default `origin/main`).
+  `ruff` and other checks run via `pre-commit`.
 
 ### C++ style guide
 
@@ -63,6 +64,10 @@ Avoid using others unless explicitly requested.
 | C++ tests         | `ctest -j"$(nproc)" --test-dir <build> --output-on-failure`                                                                             |
 | Python tests      | `PYTHONPATH="$PWD/python/src" pytest -vs python/test`                                                                                   |
 | Python doctest    | `PYTHONPATH="$PWD/python/src" cmake --build <build> --target NuriPythonDoctest`                                                         |
-| Format & lint C++ | `scripts/run_clang_tools.sh -j"$(nproc)" [files...]`                                                                                    |
-| Coverage          | `scripts/check_coverage.sh <build>`                                                                                                     |
+| Format & lint C++ | `scripts/run_clang_tools.sh [-d [<ref>]] [-b <build>] [files...]`                                                                       |
+| Coverage          | `scripts/check_coverage.sh [--cpp] [--python] [--html] [--json] [<build>]`                                                              |
 | C++ API docs      | `cmake --build <build> --target NuriDocs`                                                                                               |
+
+Both scripts take `-h` for full usage and default the build dir to
+`<project_root>/build`. `check_coverage.sh` runs the whole suite unless
+`--cpp`/`--python` narrows it, and `--html`/`--json` add a gcovr report.

--- a/include/nuri/fmt/cif.h
+++ b/include/nuri/fmt/cif.h
@@ -152,8 +152,6 @@ namespace internal {
       kInapplicable = 1U << 31,  // .
     };
 
-    CifValue(): type_(Type::kUnknown) { }
-
     CifValue(std::string_view value, internal::CifToken type): value_(value) {
       if (type == internal::CifToken::kQuotedValue) {
         type_ = Type::kString;

--- a/include/nuri/fmt/cif.h
+++ b/include/nuri/fmt/cif.h
@@ -7,6 +7,7 @@
 #define NURI_FMT_CIF_H_
 
 //! @cond
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <istream>
@@ -18,6 +19,7 @@
 #include <vector>
 
 #include <absl/base/attributes.h>
+#include <absl/base/optimization.h>
 #include <absl/container/btree_map.h>
 #include <absl/log/absl_check.h>
 #include <absl/strings/str_cat.h>
@@ -143,10 +145,11 @@ namespace internal {
 
       // Reserved for future use
 
+      // Nurikit-specific: non-finite float encountered
+      kFloatNonfinite = 1U << 2,
+
       kUnknown = 1U << 30,       // ?
       kInapplicable = 1U << 31,  // .
-
-      kNull = kUnknown | kInapplicable,  // any null value
     };
 
     CifValue(): type_(Type::kInapplicable) { }
@@ -189,6 +192,11 @@ namespace internal {
       return CifValue("", is_unk ? Type::kUnknown : Type::kInapplicable);
     }
 
+    template <class T>
+    static CifValue float_nonfinite(T &&repr) {
+      return CifValue(std::forward<T>(repr), Type::kFloatNonfinite);
+    }
+
     std::string_view operator*() const { return value_; }
     std::string_view value() const { return value_; }
 
@@ -197,7 +205,7 @@ namespace internal {
     Type type() const { return type_; }
 
     constexpr bool is_null() const {
-      return static_cast<bool>(type_ & Type::kNull);
+      return static_cast<bool>(type_ & (Type::kUnknown | Type::kInapplicable));
     }
 
     constexpr operator bool() const { return !is_null(); }
@@ -435,15 +443,34 @@ internal::CifValue cif_value(T value, int width = 0) {
       absl::StrFormat("%0*d", width, static_cast<std::int64_t>(value)));
 }
 
+namespace internal {
+  extern CifValue cif_float_nonfinite(double value, bool coerce_nonfinite,
+                                      bool is_unk);
+}
+
 /**
  * @brief Create a floating-point CIF value.
  * @param value the number to store.
  * @param precision if non-negative, format with this many digits after the
  *        decimal point; otherwise use the shortest round-trip representation.
+ * @param coerce_nonfinite if true, coerce non-finite values to a "safe"
+ *        representation:
+ *         - @c NaN -> @c ? or @c . depending on @p is_unk
+ *         - @c +Inf -> @c std::numeric_limits<double>::max()
+ *         - @c -Inf -> @c std::numeric_limits<double>::lowest()
+ * @param is_unk if true, non-finite values are coerced to @c ?; otherwise they
+ *        are coerced to @c . (inapplicable).
  * @return An unquoted CifValue holding the formatted number.
  */
 template <class T, std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
-internal::CifValue cif_value(T value, int precision = -1) {
+internal::CifValue cif_value(T value, int precision = -1,
+                             bool coerce_nonfinite = false,
+                             bool is_unk = false) {
+  if (ABSL_PREDICT_FALSE(!std::isfinite(value))) {
+    return internal::cif_float_nonfinite(static_cast<double>(value),
+                                         coerce_nonfinite, is_unk);
+  }
+
   if (precision < 0)
     return internal::CifValue::generic(absl::StrCat(value));
 

--- a/include/nuri/fmt/cif.h
+++ b/include/nuri/fmt/cif.h
@@ -453,13 +453,15 @@ namespace internal {
  * @param value the number to store.
  * @param precision if non-negative, format with this many digits after the
  *        decimal point; otherwise yields at most 6 significant digits.
- * @param coerce_nonfinite if true, coerce non-finite values to a "safe"
- *        representation:
+ * @param coerce_nonfinite if true, coerce non-finite values to a
+ *        CIF-representable form that reparses faithfully:
  *         - @c NaN -> @c ? or @c . depending on @p is_unk
- *         - @c +Inf -> @c std::numeric_limits<double>::max()
- *         - @c -Inf -> @c std::numeric_limits<double>::lowest()
- * @param is_unk if true, non-finite values are coerced to @c ?; otherwise they
- *        are coerced to @c . (inapplicable).
+ *         - @c +Inf -> @c 8e+88888888
+ *         - @c -Inf -> @c -8e+88888888
+ *        The infinity sentinel overflows on reparse, so any IEEE-conformant
+ *        parser (up to @c binary256) reads it back as the original infinity.
+ * @param is_unk if true, @c NaN is coerced to @c ?; otherwise it is coerced to
+ *        @c . (inapplicable).
  * @return An unquoted CifValue holding the formatted number.
  */
 template <class T, std::enable_if_t<std::is_floating_point_v<T>, int> = 0>

--- a/include/nuri/fmt/cif.h
+++ b/include/nuri/fmt/cif.h
@@ -452,7 +452,7 @@ namespace internal {
  * @brief Create a floating-point CIF value.
  * @param value the number to store.
  * @param precision if non-negative, format with this many digits after the
- *        decimal point; otherwise use the shortest round-trip representation.
+ *        decimal point; otherwise yields at most 6 significant digits.
  * @param coerce_nonfinite if true, coerce non-finite values to a "safe"
  *        representation:
  *         - @c NaN -> @c ? or @c . depending on @p is_unk

--- a/include/nuri/fmt/cif.h
+++ b/include/nuri/fmt/cif.h
@@ -152,7 +152,7 @@ namespace internal {
       kInapplicable = 1U << 31,  // .
     };
 
-    CifValue(): type_(Type::kInapplicable) { }
+    CifValue(): type_(Type::kUnknown) { }
 
     CifValue(std::string_view value, internal::CifToken type): value_(value) {
       if (type == internal::CifToken::kQuotedValue) {
@@ -460,14 +460,14 @@ namespace internal {
  *         - @c -Inf -> @c -8e+88888888
  *        The infinity sentinel overflows on reparse, so any IEEE-conformant
  *        parser (up to @c binary256) reads it back as the original infinity.
- * @param is_unk if true, @c NaN is coerced to @c ?; otherwise it is coerced to
- *        @c . (inapplicable).
+ * @param is_unk if true (the default), @c NaN is coerced to @c ? (unknown);
+ *        otherwise it is coerced to @c . (inapplicable).
  * @return An unquoted CifValue holding the formatted number.
  */
 template <class T, std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
 internal::CifValue cif_value(T value, int precision = -1,
                              bool coerce_nonfinite = false,
-                             bool is_unk = false) {
+                             bool is_unk = true) {
   if (ABSL_PREDICT_FALSE(!std::isfinite(value))) {
     return internal::cif_float_nonfinite(static_cast<double>(value),
                                          coerce_nonfinite, is_unk);

--- a/python/src/nuri/fmt/cif.cpp
+++ b/python/src/nuri/fmt/cif.cpp
@@ -58,6 +58,7 @@ struct ColumnFormat {
   bool raw = false;          // str:   generic literal vs. quoted string
   bool short_form = false;   // bool:  y/n vs. yes/no
   bool null_unknown = true;  // None:  '?' (unknown) vs. '.' (inapplicable)
+  bool coerce_nonfinite = false;  // float: coerce NaN/Inf to a safe value
 };
 
 pyt::List<pyt::Optional<py::str>> cif_table_row(const internal::CifTable &table,
@@ -86,7 +87,8 @@ internal::CifValue py_to_cif_value(py::handle cell, const ColumnFormat &fmt) {
   if (py::isinstance<py::int_>(cell))
     return cif_value(cell.cast<std::int64_t>(), fmt.width);
   if (py::isinstance<py::float_>(cell))
-    return cif_value(cell.cast<double>(), fmt.precision);
+    return cif_value(cell.cast<double>(), fmt.precision, fmt.coerce_nonfinite,
+                     fmt.null_unknown);
   if (py::isinstance<internal::CifValue>(cell))
     return cell.cast<internal::CifValue>();
 
@@ -152,6 +154,8 @@ parse_column_formats(const CifKeys &keys,
           throw py::value_error("precision must be non-negative");
       } else if (name == "null_token") {
         fmt.null_unknown = parse_null_token(val.cast<std::string_view>());
+      } else if (name == "coerce_nonfinite") {
+        fmt.coerce_nonfinite = val.cast<bool>();
       } else {
         throw py::value_error(absl::StrCat("Unknown formatter option: ", name));
       }
@@ -672,18 +676,31 @@ Store an integer CIF value.
 :param value: The integer to store.
 :param width: If positive, zero-pad the number to at least this many digits.
 )doc");
-  cv.def(py::init([](double value, std::optional<int> prec) {
+  cv.def(py::init([](double value, std::optional<int> prec,
+                     bool coerce_nonfinite, std::string_view null_token) {
            if (prec.has_value() && prec.value() < 0)
              throw py::value_error("precision must be non-negative");
 
-           return cif_value(value, prec.value_or(-1));
+           return cif_value(value, prec.value_or(-1), coerce_nonfinite,
+                            parse_null_token(null_token));
          }),
-         py::arg("value"), py::arg("precision") = py::none(), R"doc(
+         py::arg("value"), py::arg("precision") = py::none(),
+         py::arg("coerce_nonfinite") = false, py::arg("null_token") = "?",
+         R"doc(
 Store a floating-point CIF value.
 
 :param value: The number to store.
-:param precision: Digits after the decimal point; if ``None`` (the default), use
-  the shortest round-trip representation. Must be non-negative if provided.
+:param precision: Digits after the decimal point; if ``None`` (the default),
+  yields at most 6 significant digits. Must be non-negative if provided.
+:param coerce_nonfinite: How to handle a non-finite ``value``. If ``False`` (the
+  default), a non-finite value has no valid CIF representation and raises
+  :exc:`ValueError` when serialized. If ``True``, ``NaN`` becomes the null value
+  chosen by ``null_token`` and ``+/-Inf`` becomes the largest/smallest finite
+  ``float``.
+:param null_token: The CIF null token that ``NaN`` is coerced to when
+  ``coerce_nonfinite`` is ``True``: ``"?"`` (the default) for unknown, or
+  ``"."`` for inapplicable. Ignored for finite values.
+:raises ValueError: If ``null_token`` is not ``"?"`` or ``"."``.
 )doc");
   cv.def(py::init([](const py::none &, std::string_view null_token) {
            return internal::CifValue::null(parse_null_token(null_token));

--- a/python/src/nuri/fmt/cif.cpp
+++ b/python/src/nuri/fmt/cif.cpp
@@ -734,9 +734,7 @@ Serialize a CIF block to a CIF 1.1 string.
 :param align: Whether to pad the columns of ``loop_`` tables so that values
   line up. Defaults to ``False``.
 :return: The serialized CIF string.
-:raises ValueError: If a value cannot be represented in CIF 1.1 (e.g. a
-  multi-line value with a line beginning with ``;`` or with significant
-  trailing whitespace).
+:raises ValueError: If a value cannot be represented in CIF 1.1.
 
 .. note::
   A ``global_`` block (only ever produced by the parser, from a STAR file) is

--- a/python/src/nuri/fmt/cif.cpp
+++ b/python/src/nuri/fmt/cif.cpp
@@ -695,8 +695,9 @@ Store a floating-point CIF value.
 :param coerce_nonfinite: How to handle a non-finite ``value``. If ``False`` (the
   default), a non-finite value has no valid CIF representation and raises
   :exc:`ValueError` when serialized. If ``True``, ``NaN`` becomes the null value
-  chosen by ``null_token`` and ``+/-Inf`` becomes the largest/smallest finite
-  ``float``.
+  chosen by ``null_token`` and ``+/-Inf`` becomes the sentinel
+  ``+/-8e+88888888``, which any IEEE-conformant parser (up to ``binary256``)
+  reads back as the original infinity.
 :param null_token: The CIF null token that ``NaN`` is coerced to when
   ``coerce_nonfinite`` is ``True``: ``"?"`` (the default) for unknown, or
   ``"."`` for inapplicable. Ignored for finite values.

--- a/python/test/fmt/cif_test.py
+++ b/python/test/fmt/cif_test.py
@@ -4,6 +4,7 @@
 #
 
 import logging
+import math
 from pathlib import Path
 
 import pytest
@@ -346,6 +347,57 @@ def test_cif_table_formatter_kwargs_strict():
 def test_cif_value_bad_null_token():
     with pytest.raises(ValueError, match="null_token"):
         Value(None, null_token="x")
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+def test_write_cif_nonfinite_rejected(value):
+    # non-finite floats have no valid CIF representation; rejected by default,
+    # whether given as a plain float or an explicit Value.
+    for cell in (value, Value(value)):
+        block = Block(Frame("d", [Table(["a.x"], [[cell]])]))
+        with pytest.raises(ValueError, match=r"(?i)non-finite"):
+            write(block)
+
+
+def test_write_cif_nonfinite_coerced_nan():
+    # NaN coerces to the null token chosen by null_token, via both the Value
+    # constructor and the per-column formatter.
+    table = Table(
+        ["v.u", "v.i", "v.j"],
+        [
+            [
+                Value(math.nan, coerce_nonfinite=True),
+                Value(math.nan, coerce_nonfinite=True, null_token="."),
+                math.nan,
+            ]
+        ],
+        formatter_kwargs={
+            "v.j": {"coerce_nonfinite": True, "null_token": "."}
+        },
+    )
+    text = write(Block(Frame("d", [table])))
+    assert "_v.u ?" in text
+    assert "_v.i ." in text
+    assert "_v.j ." in text
+
+
+def test_write_cif_nonfinite_coerced_inf():
+    table = Table(
+        ["v.p", "v.n"],
+        [[math.inf, -math.inf]],
+        formatter_kwargs={
+            "v.p": {"coerce_nonfinite": True},
+            "v.n": {"coerce_nonfinite": True},
+        },
+    )
+    text = write(Block(Frame("d", [table])))
+    assert "_v.p 1.79769e+308" in text
+    assert "_v.n -1.79769e+308" in text
+
+
+def test_cif_value_float_bad_null_token():
+    with pytest.raises(ValueError, match="null_token"):
+        Value(1.5, null_token="x")
 
 
 def test_write_cif_bad_type():

--- a/python/test/fmt/cif_test.py
+++ b/python/test/fmt/cif_test.py
@@ -391,8 +391,11 @@ def test_write_cif_nonfinite_coerced_inf():
         },
     )
     text = write(Block(Frame("d", [table])))
-    assert "_v.p 1.79769e+308" in text
-    assert "_v.n -1.79769e+308" in text
+    assert "_v.p 8e+88888888" in text
+    assert "_v.n -8e+88888888" in text
+    # the sentinel reparses faithfully back to infinity
+    assert float("8e+88888888") == math.inf
+    assert float("-8e+88888888") == -math.inf
 
 
 def test_cif_value_float_bad_null_token():

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -12,11 +12,39 @@ output_args=()
 output=''
 jobs="$(nproc)"
 
-while getopts ':j:-:' opt; do
+usage() {
+	cat <<EOF
+Usage: $0 [OPTIONS] [BUILD_DIR]
+
+Run the test suite(s) against a coverage build and report with gcovr.
+BUILD_DIR is the CMake build directory (default: ${prj_root}/build).
+
+Options:
+      --cpp      Run only the C++ tests (ctest).
+      --python   Run only the Python tests (pytest + doctest).
+                 Without --cpp or --python, both suites run.
+      --html     Write an HTML report to
+                 BUILD_DIR/coverage/html/index.html.
+      --json     Write a Coveralls JSON report to
+                 BUILD_DIR/coverage/json/coverage.json.
+  -j N           Number of parallel jobs (default: ${jobs}).
+  -h, --help     Show this help and exit.
+EOF
+}
+
+while getopts ':hj:-:' opt; do
 	case "$opt" in
+	h)
+		usage
+		exit 0
+		;;
 	j) jobs="$OPTARG" ;;
 	-)
 		case "$OPTARG" in
+		help)
+			usage
+			exit 0
+			;;
 		cpp) cpp_test=true ;;
 		python) py_test=true ;;
 		html)
@@ -29,23 +57,26 @@ while getopts ':j:-:' opt; do
 			;;
 		*)
 			echo >&2 "Unknown option: --$OPTARG"
+			usage >&2
 			exit 1
 			;;
 		esac
 		;;
 	:)
 		echo >&2 "Option -$OPTARG requires an argument"
+		usage >&2
 		exit 1
 		;;
 	*)
 		echo >&2 "Unknown option: -$OPTARG"
+		usage >&2
 		exit 1
 		;;
 	esac
 done
 
 shift $((OPTIND - 1))
-build_dir="$(realpath "${1-build}")"
+build_dir="$(realpath "${1-${prj_root}/build}")"
 
 if [[ $cpp_test = false && $py_test = false ]]; then
 	cpp_test=true

--- a/scripts/run_clang_tools.sh
+++ b/scripts/run_clang_tools.sh
@@ -6,54 +6,144 @@
 
 set -euo pipefail
 
-type clang-format clang-tidy
-
 project_root="$(dirname "$(dirname "$(realpath "$0")")")"
-cd "$project_root"
 
-if [[ ! -d build ]]; then
-	echo "Build directory not found. Configure the project with cmake."
-	exit 1
-fi
-
-cf_args=("-i")
+build_dir=""
+diff_base=""
 nproc="$(nproc)"
 
-ct_args=(--warnings-as-errors='*')
+format_args=(-i)
+
+tidy_args=(--warnings-as-errors='*')
 if command -v gcc &>/dev/null; then
-	ct_args+=(
+	tidy_args+=(
 		--extra-arg="--gcc-install-dir=$(dirname "$(gcc -print-libgcc-file-name)")"
 	)
 fi
 
-while getopts 'cj:x:' opt; do
+function usage() {
+	cat <<EOF
+Usage: $0 [OPTIONS] [--] [FILE...]
+
+Run clang-format and clang-tidy over the project sources. With no FILE arguments
+(and without -d), the whole tree is checked.
+
+Options:
+  -b DIR        Build directory holding the compilation database.
+                (default: ${project_root}/build)
+  -d [REFSPEC]  Diff mode: check only files changed vs REFSPEC.
+                (default REFSPEC: origin/main)
+  -c            Check only: run clang-format in dry-run (--Werror) instead
+                of rewriting files in place.
+  -x ARG        Pass an extra --extra-arg=ARG to clang-tidy (repeatable).
+  -j N          Number of parallel jobs (default: ${nproc}).
+  -h            Show this help and exit.
+
+Use -- to end option parsing (e.g. '-d --' keeps the default base without
+consuming the next token).
+EOF
+}
+
+while getopts 'b:dcx:j:h' opt; do
 	case "$opt" in
-	c) cf_args=(-n --Werror) ;;
+	b)
+		build_dir="$OPTARG"
+		build_dir="$(realpath "$build_dir")"
+		;;
+	d)
+		# Optional argument: '-d' alone defaults to origin/main, while
+		# '-d <refspec>' overrides the base. getopts has no native optional
+		# argument, so peek at the next token and consume it only if it is
+		# neither another option nor the '--' terminator (both match '-*').
+		diff_base="origin/main"
+		if [[ -n "${!OPTIND-}" && "${!OPTIND}" != -* ]]; then
+			diff_base="${!OPTIND}"
+			OPTIND=$((OPTIND + 1))
+		fi
+		;;
+	c) format_args=(-n --Werror) ;;
+	x) tidy_args+=(--extra-arg="$OPTARG") ;;
 	j) nproc="$OPTARG" ;;
-	x) ct_args+=(--extra-arg="$OPTARG") ;;
-	*) break ;;
+	h)
+		usage
+		exit 0
+		;;
+	*)
+		usage >&2
+		exit 1
+		;;
 	esac
 done
 
 shift $((OPTIND - 1))
 
-if [[ $# -eq 0 ]]; then
-	tidy_paths=(include src python/include python/src)
-	format_paths=("${tidy_paths[@]}" test)
-else
-	tidy_paths=("$@")
-	format_paths=("$@")
+type clang-format clang-tidy
+
+if [[ -z $build_dir ]]; then
+	build_dir="${project_root}/build"
 fi
 
-tmpd="$(mktemp -d)"
-trap 'rm -rf "$tmpd"' INT TERM EXIT
+if [[ ! -d $build_dir ]]; then
+	echo "Build directory not found. Configure the project with cmake."
+	exit 1
+fi
 
-find "${tidy_paths[@]}" \
-	\( -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' \) \
-	-print0 >"$tmpd/tidy-checks"
-find "${format_paths[@]}" \
-	\( -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' \) \
-	-print0 >"$tmpd/format-checks"
+tidy_args+=(-p "$build_dir")
 
-xargs -0 -P"$nproc" -n1 clang-format "${cf_args[@]}" <"$tmpd/format-checks"
-xargs -0 -P"$nproc" -n1 clang-tidy -p build "${ct_args[@]}" <"$tmpd/tidy-checks"
+if [[ -n $diff_base ]]; then
+	function list-changed() {
+		git -C "$project_root" diff "$diff_base" \
+			--name-only -z --diff-filter=d --line-prefix="${project_root}/" \
+			-- "$@"
+	}
+
+	mapfile -d '' -t tidy_paths < <(
+		list-changed 'include/*' 'src/*' 'python/include/*' 'python/src/*'
+	)
+
+	mapfile -d '' -t format_paths < <(list-changed 'test/*')
+	format_paths+=("${tidy_paths[@]}")
+elif [[ $# -eq 0 ]]; then
+	tidy_paths=("$project_root"/{include,src,python/include,python/src})
+	format_paths=("${tidy_paths[@]}" "$project_root"/test)
+else
+	format_paths=("$@")
+
+	tidy_paths=()
+	for f in "$@"; do
+		case "$f" in
+		*include/* | *src/*)
+			tidy_paths+=("$f")
+			;;
+		esac
+	done
+fi
+
+function search-exec() {
+	local prog="$1"
+	shift
+
+	if [[ $# -eq 0 ]]; then
+		echo >&2 "No source files to check with ${prog}."
+		return
+	fi
+
+	case "$prog" in
+	clang-tidy)
+		local -a args=("${tidy_args[@]}")
+		;;
+	clang-format)
+		local -a args=("${format_args[@]}")
+		;;
+	*)
+		echo >&2 "Unknown program: ${prog}"
+		return 1
+		;;
+	esac
+
+	find "$@" \( -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' \) -print0 |
+		xargs -0 -r -P"$nproc" -n1 "$prog" "${args[@]}"
+}
+
+search-exec clang-tidy "${tidy_paths[@]}"
+search-exec clang-format "${format_paths[@]}"

--- a/src/fmt/cif.cpp
+++ b/src/fmt/cif.cpp
@@ -6,8 +6,10 @@
 #include "nuri/fmt/cif.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <iostream>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -280,7 +282,6 @@ bool CifValue::operator==(std::string_view other) const {
 std::ostream &operator<<(std::ostream &os, const CifValue &value) {
   using ValueType = CifValue::Type;
 
-  // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
   switch (value.type()) {
   case ValueType::kGeneric:
     return os << value.value();
@@ -290,11 +291,24 @@ std::ostream &operator<<(std::ostream &os, const CifValue &value) {
     return os << '?';
   case ValueType::kInapplicable:
     return os << '.';
-  default:
-    ABSL_UNREACHABLE();
+  case ValueType::kFloatNonfinite:
+    return os << "<non-finite: " << value.value() << '>';
   }
+  ABSL_UNREACHABLE();
 }
 // GCOV_EXCL_STOP
+
+CifValue cif_float_nonfinite(double value, bool coerce_nonfinite, bool is_unk) {
+  if (!coerce_nonfinite)
+    return CifValue::float_nonfinite(absl::StrCat(value));
+
+  if (std::isnan(value))
+    return is_unk ? CifValue::unknown() : CifValue::inapplicable();
+
+  return CifValue::generic(
+      absl::StrCat(value > 0 ? std::numeric_limits<double>::max()
+                             : std::numeric_limits<double>::lowest()));
+}
 
 void CifTable::add_data(CifValue &&value) {
   if (rows_.empty() || rows_.back().size() == keys_.size())
@@ -636,7 +650,6 @@ bool looks_like_number(std::string_view s) {
 }  // namespace
 
 CifValueKind write_cif_value(std::string &out, const CifValue &value) {
-  // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
   switch (value.type()) {
   case CifValue::Type::kUnknown:
     out.push_back('?');
@@ -644,7 +657,12 @@ CifValueKind write_cif_value(std::string &out, const CifValue &value) {
   case CifValue::Type::kInapplicable:
     out.push_back('.');
     return CifValueKind::kInline;
-  default:
+  case CifValue::Type::kFloatNonfinite:
+    out = absl::StrCat("Non-finite float value cannot be written: ",
+                       value.value());
+    return CifValueKind::kError;
+  case CifValue::Type::kGeneric:
+  case CifValue::Type::kString:
     break;
   }
 

--- a/src/fmt/cif.cpp
+++ b/src/fmt/cif.cpp
@@ -9,7 +9,6 @@
 #include <cmath>
 #include <cstddef>
 #include <iostream>
-#include <limits>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -305,9 +304,9 @@ CifValue cif_float_nonfinite(double value, bool coerce_nonfinite, bool is_unk) {
   if (std::isnan(value))
     return is_unk ? CifValue::unknown() : CifValue::inapplicable();
 
-  return CifValue::generic(
-      absl::StrCat(value > 0 ? std::numeric_limits<double>::max()
-                             : std::numeric_limits<double>::lowest()));
+  // Inf sentinel: overflows every IEEE format ≤ binary256, re-lexes to inf;
+  // "88888888" (eight 8s) reads as the infinity symbol for humans
+  return CifValue::generic(value > 0 ? "8e+88888888" : "-8e+88888888");
 }
 
 void CifTable::add_data(CifValue &&value) {

--- a/src/fmt/mmcif.cpp
+++ b/src/fmt/mmcif.cpp
@@ -88,7 +88,7 @@ public:
   }
 
   const internal::CifValue &operator[](int row) const {
-    static const internal::CifValue placeholder {};
+    static const internal::CifValue placeholder = internal::CifValue::unknown();
 
     if (ABSL_PREDICT_FALSE(!*this))
       return placeholder;

--- a/test/fmt/cif_test.cpp
+++ b/test/fmt/cif_test.cpp
@@ -46,9 +46,11 @@
 
 #include "nuri/fmt/cif.h"
 
+#include <cmath>
 #include <cstddef>
 #include <fstream>
 #include <initializer_list>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -947,6 +949,53 @@ TEST(CifWriteValueTest, RoundTrip) {
                              "  padded  " }) {
     expect_roundtrips(CifValue::generic(s));
   }
+}
+
+TEST(CifWriteValueTest, NonfiniteRejectedByDefault) {
+  constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+  constexpr double inf = std::numeric_limits<double>::infinity();
+
+  for (double v: { nan, inf, -inf }) {
+    CifValue value = cif_value(v);
+    EXPECT_EQ(value.type(), CifValue::Type::kFloatNonfinite);
+    EXPECT_FALSE(value.is_null());
+
+    std::string out;
+    EXPECT_EQ(write_cif_value(out, value), CifValueKind::kError)
+        << "value: " << v;
+    EXPECT_PRED2(str_case_contains, out, "non-finite");
+  }
+
+  // float, not only double
+  CifValue f = cif_value(std::numeric_limits<float>::infinity());
+  EXPECT_EQ(f.type(), CifValue::Type::kFloatNonfinite);
+}
+
+TEST(CifWriteValueTest, NonfiniteCoercedNaN) {
+  constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+
+  CifValue inapplicable = cif_value(nan, -1, true, false);
+  EXPECT_EQ(inapplicable.type(), CifValue::Type::kInapplicable);
+  EXPECT_TRUE(inapplicable.is_null());
+  EXPECT_EQ(write_value(inapplicable), ".");
+
+  CifValue unknown = cif_value(nan, -1, true, true);
+  EXPECT_EQ(unknown.type(), CifValue::Type::kUnknown);
+  EXPECT_TRUE(unknown.is_null());
+  EXPECT_EQ(write_value(unknown), "?");
+}
+
+TEST(CifWriteValueTest, NonfiniteCoercedInf) {
+  constexpr double inf = std::numeric_limits<double>::infinity();
+
+  // +Inf -> double max, -Inf -> double lowest; StrCat already emits exponential
+  // notation, which the CIF numeric grammar accepts.
+  EXPECT_EQ(write_value(cif_value(inf, -1, true)), "1.79769e+308");
+  EXPECT_EQ(write_value(cif_value(-inf, -1, true)), "-1.79769e+308");
+
+  // coerced infinities re-lex as plain numbers
+  expect_roundtrips(cif_value(inf, -1, true));
+  expect_roundtrips(cif_value(-inf, -1, true));
 }
 
 // Collect a frame into an order-independent {key -> column values} map so that

--- a/test/fmt/cif_test.cpp
+++ b/test/fmt/cif_test.cpp
@@ -809,7 +809,8 @@ void expect_roundtrips(const CifValue &value) {
 TEST(CifWriteValueTest, NullValues) {
   EXPECT_EQ(write_value(CifValue::unknown()), "?");
   EXPECT_EQ(write_value(CifValue::inapplicable()), ".");
-  EXPECT_EQ(write_value(CifValue()), ".");
+  // a default-constructed value is unknown ('?'), the default null everywhere
+  EXPECT_EQ(write_value(CifValue()), "?");
 }
 
 TEST(CifWriteValueTest, BareValues) {
@@ -984,6 +985,9 @@ TEST(CifWriteValueTest, NonfiniteCoercedNaN) {
   EXPECT_EQ(unknown.type(), CifValue::Type::kUnknown);
   EXPECT_TRUE(unknown.is_null());
   EXPECT_EQ(write_value(unknown), "?");
+
+  // default coercion is unknown ('?'), matching the Python binding default
+  EXPECT_EQ(write_value(cif_value(nan, -1, true)), "?");
 }
 
 TEST(CifWriteValueTest, NonfiniteCoercedInf) {

--- a/test/fmt/cif_test.cpp
+++ b/test/fmt/cif_test.cpp
@@ -59,6 +59,7 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/strings/match.h>
+#include <absl/strings/numbers.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_join.h>
 
@@ -988,14 +989,23 @@ TEST(CifWriteValueTest, NonfiniteCoercedNaN) {
 TEST(CifWriteValueTest, NonfiniteCoercedInf) {
   constexpr double inf = std::numeric_limits<double>::infinity();
 
-  // +Inf -> double max, -Inf -> double lowest; StrCat already emits exponential
-  // notation, which the CIF numeric grammar accepts.
-  EXPECT_EQ(write_value(cif_value(inf, -1, true)), "1.79769e+308");
-  EXPECT_EQ(write_value(cif_value(-inf, -1, true)), "-1.79769e+308");
+  // +/-Inf -> a sentinel whose magnitude overflows on reparse, so an
+  // IEEE-conformant parser reads it back as the original infinity.
+  EXPECT_EQ(write_value(cif_value(inf, -1, true)), "8e+88888888");
+  EXPECT_EQ(write_value(cif_value(-inf, -1, true)), "-8e+88888888");
 
-  // coerced infinities re-lex as plain numbers
+  // the sentinel is a valid CIF number and re-lexes verbatim
   expect_roundtrips(cif_value(inf, -1, true));
   expect_roundtrips(cif_value(-inf, -1, true));
+
+  // an abseil parse of the emitted value overflows back to the infinity
+  double d;
+  ASSERT_TRUE(absl::SimpleAtod(write_value(cif_value(inf, -1, true)), &d));
+  EXPECT_TRUE(std::isinf(d));
+  EXPECT_GT(d, 0);
+  ASSERT_TRUE(absl::SimpleAtod(write_value(cif_value(-inf, -1, true)), &d));
+  EXPECT_TRUE(std::isinf(d));
+  EXPECT_LT(d, 0);
 }
 
 // Collect a frame into an order-independent {key -> column values} map so that

--- a/test/fmt/cif_test.cpp
+++ b/test/fmt/cif_test.cpp
@@ -809,8 +809,6 @@ void expect_roundtrips(const CifValue &value) {
 TEST(CifWriteValueTest, NullValues) {
   EXPECT_EQ(write_value(CifValue::unknown()), "?");
   EXPECT_EQ(write_value(CifValue::inapplicable()), ".");
-  // a default-constructed value is unknown ('?'), the default null everywhere
-  EXPECT_EQ(write_value(CifValue()), "?");
 }
 
 TEST(CifWriteValueTest, BareValues) {


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Do all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [x] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #...

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CIF write behavior for NaN/Inf (new errors by default) and touches serialization paths used by Python and mmCIF readers; coercion is opt-in so existing finite-float output should be unchanged.
> 
> **Overview**
> **CIF serialization** now treats NaN and ±Inf explicitly instead of letting them slip through as invalid literals. By default, non-finite floats become a dedicated `kFloatNonfinite` value and **fail on write** with a clear error; optional `coerce_nonfinite` maps NaN to `?`/`.` and infinities to the `±8e+88888888` sentinel so round-trips stay IEEE-safe.
> 
> The same behavior is exposed in **Python** via `Value(..., coerce_nonfinite=..., null_token=...)` and per-column `formatter_kwargs`. Float default-precision docs are updated to “at most 6 significant digits.” `CifValue` loses the default inapplicable constructor; mmCIF missing-column placeholders use explicit `unknown()` instead.
> 
> **Dev tooling**: `run_clang_tools.sh` gains `-d [ref]` diff mode, `-b`, and help; `check_coverage.sh` adds `--cpp`/`--python`/`--html`/`--json` and `-h`. **AGENTS.md** documents the new flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f3c4023a45901e1d2698ec752b391f08dcad949. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->