### PR TITLE
fix: unify and harden input validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,8 @@
   `nuri_add_test()`); Python under `python/test/` (pytest).
 - **Docs** - **Write docs/docstrings only when asked.** C++ is Doxygen (`docs/`),
   Python is Sphinx (`python/docs/`). For Python docstrings, always use
-  Sphinx-compatible reST.
+  Sphinx-compatible reST. Document an exception only if it is non-obvious or
+  part of the API contract.
 - **Format & lint** - C++ with `scripts/run_clang_tools.sh` (slow; pass
   `-d [<ref>]` to check only files changed vs `<ref>`, default `origin/main`).
   `ruff` and other checks run via `pre-commit`.

--- a/include/nuri/core/geometry.h
+++ b/include/nuri/core/geometry.h
@@ -432,6 +432,10 @@ auto msd(const ML1 &a, const ML2 &b) {
 }
 
 namespace internal {
+  constexpr double safe_reciprocal(double val, double eps = 1e-12) {
+    return val > eps ? 1 / val : 0;
+  }
+
   constexpr double safe_normalizer(double sqn, double eps = 1e-12) {
     return sqn > eps ? 1 / std::sqrt(sqn) : 0;
   }

--- a/include/nuri/core/geometry.h
+++ b/include/nuri/core/geometry.h
@@ -168,6 +168,11 @@ private:
  * @warning The cutoff must be a positive, finite number. Building with a
  *          non-positive or non-finite cutoff is undefined behavior (the voxel
  *          index divides coordinates by the cutoff); callers must validate it.
+ * @warning The cutoff must also be coarse enough that the point cloud spans at
+ *          most kMaxCells voxels. A finer one is widened to span the whole
+ *          cloud in a single voxel, so queries then report every point;
+ *          cutoff() returns the widened value, and callers that need the
+ *          requested cutoff honored must validate it.
  */
 class VoxelGrid {
 public:
@@ -259,8 +264,8 @@ private:
   Array3i dims_;
   ArrayXi cell_offset_;
   ArrayXi cell_pts_;
-  double cutoff_;
-  int max_occ_;
+  double cutoff_ = 0;
+  int max_occ_ = 0;
 };
 
 namespace constants {

--- a/include/nuri/core/geometry.h
+++ b/include/nuri/core/geometry.h
@@ -34,7 +34,7 @@ namespace internal {
 
     int operator[](int i) const { return child(i); }
 
-    bool leaf() const { return nleaf_ <= 8; }
+    bool leaf() const;
 
     int begin() const { return begin_; }
     int end() const { return begin_ + nleaf_; }
@@ -42,9 +42,9 @@ namespace internal {
     int nleaf() const { return nleaf_; }
 
   private:
-    Array8i children_;  // < 0 -> not exist, >= 0 -> index of child
+    Array8i children_;  // child index (>= 0) or a sentinel
     int begin_;
-    int nleaf_;  // <= 8 -> leaf, > 8 -> internal node
+    int nleaf_;
   };
 }  // namespace internal
 
@@ -125,6 +125,8 @@ public:
 
   int bucket_size() const { return bucket_size_; }
 
+  int max_nleaf() const { return max_nleaf_; }
+
   const ArrayXi &idxs() const { return idxs_; }
 
   const internal::OCTreeNode &node(int i) const { return nodes_[i]; }
@@ -141,6 +143,7 @@ private:
   ArrayXi idxs_;
 
   int bucket_size_ = 32;
+  int max_nleaf_ = 0;
 };
 
 /**

--- a/include/nuri/core/geometry.h
+++ b/include/nuri/core/geometry.h
@@ -164,6 +164,10 @@ private:
  * `pts()` corresponds to the original input point `cell_pts()[p]`. The
  * original point set is *not* referenced after rebuild() returns, so the
  * caller is free to mutate or destroy it.
+ *
+ * @warning The cutoff must be a positive, finite number. Building with a
+ *          non-positive or non-finite cutoff is undefined behavior (the voxel
+ *          index divides coordinates by the cutoff); callers must validate it.
  */
 class VoxelGrid {
 public:
@@ -599,9 +603,14 @@ inline double cos_dihedral(const Vector3d &a, const Vector3d &b,
  * @param normalize Whether to normalize the normal vector. Defaults to true.
  * @return The best-fit plane defined by a 4-vector (a, b, c, d), such that
  *         ax + by + cz + d = 0.
+ *
+ * @note Passing fewer than 3 points is undefined behavior (the thin-U SVD has
+ *       no third column); it is the caller's responsibility to ensure N >= 3.
  */
 template <class MatrixLike>
 Vector4d fit_plane(const MatrixLike &pts, bool normalize = true) {
+  ABSL_DCHECK_GE(pts.cols(), 3);
+
   Vector3d cntr = pts.rowwise().mean();
   MatrixXd m = pts.colwise() - cntr;
   auto svd = m.jacobiSvd(Eigen::ComputeThinU);

--- a/include/nuri/core/geometry.h
+++ b/include/nuri/core/geometry.h
@@ -42,7 +42,7 @@ namespace internal {
     int nleaf() const { return nleaf_; }
 
   private:
-    Array8i children_;  // child index (>= 0) or a sentinel
+    Array8i children_;
     int begin_;
     int nleaf_;
   };

--- a/include/nuri/utils.h
+++ b/include/nuri/utils.h
@@ -257,7 +257,12 @@ auto argsort(const Container &container, Comp op = {}) {
 template <int N = Eigen::Dynamic, int... Extra, class Container,
           class Comp = std::less<>>
 auto argpartition(const Container &container, int count, Comp op = {}) {
-  auto idxs = generate_index<N, Extra...>(std::size(container));
+  const auto size = std::size(container);
+  auto idxs = generate_index<N, Extra...>(static_cast<E::Index>(size));
+
+  if (count <= 0 || count > size)
+    return idxs;
+
   std::nth_element(idxs.begin(), idxs.begin() + count - 1, idxs.end(),
                    [&](int i, int j) {
                      return op(container[i], container[j]);

--- a/include/nuri/utils.h
+++ b/include/nuri/utils.h
@@ -248,7 +248,8 @@ auto generate_index(Eigen::Index size) {
 template <int N = Eigen::Dynamic, int... Extra, class Container,
           class Comp = std::less<>>
 auto argsort(const Container &container, Comp op = {}) {
-  auto idxs = generate_index<N, Extra...>(std::size(container));
+  auto idxs =
+      generate_index<N, Extra...>(static_cast<E::Index>(std::size(container)));
   std::sort(idxs.begin(), idxs.end(),
             [&](int i, int j) { return op(container[i], container[j]); });
   return idxs;

--- a/python/include/nuri/python/core/core_module.h
+++ b/python/include/nuri/python/core/core_module.h
@@ -730,7 +730,7 @@ The hybridization of the atom.
       "implicit_hydrogens",
       [](T &self) { return atom_prolog(self).implicit_hydrogens(); },
       [](T &self, int n) {
-        check_interval(n, "implicit_hydrogens", Bounds::kClosed, 0);
+        check_nonneg(n, "implicit_hydrogens");
         atom_prolog(self).set_implicit_hydrogens(n);
       },
       rvp::automatic,
@@ -1020,8 +1020,7 @@ The name of the atom. Returns an empty string if the name is not set.
         if (hyb)
           *hyb = get_or_throw_hyb(*hyb);
 
-        check_interval(implicit_hydrogens, "implicit_hydrogens",
-                       Bounds::kClosed, 0);
+        check_nonneg(implicit_hydrogens, "implicit_hydrogens");
         check_finite(partial_charge, "partial_charge");
 
         if (atomic_number && element != nullptr)

--- a/python/include/nuri/python/core/core_module.h
+++ b/python/include/nuri/python/core/core_module.h
@@ -656,12 +656,6 @@ void assign_conf(MatrixLike &conf, const py::handle &obj) {
   conf = mat;
 }
 
-inline int check_implicit_hydrogens(int n) {
-  if (n < 0)
-    throw py::value_error("negative number of implicit hydrogens");
-  return n;
-}
-
 inline void update_hyb(AtomData &self, constants::Hybridization hyb) {
   self.set_hybridization(get_or_throw_hyb(hyb));
 }
@@ -736,7 +730,7 @@ The hybridization of the atom.
       "implicit_hydrogens",
       [](T &self) { return atom_prolog(self).implicit_hydrogens(); },
       [](T &self, int n) {
-        n = check_implicit_hydrogens(n);
+        check_positive(n, "implicit_hydrogens", Bounds::kClosed);
         atom_prolog(self).set_implicit_hydrogens(n);
       },
       rvp::automatic,
@@ -768,6 +762,7 @@ The formal charge of the atom.
       "partial_charge",
       [](T &self) { return atom_prolog(self).partial_charge(); },
       [](T &self, double charge) {
+        check_finite(charge, "partial_charge");
         atom_prolog(self).set_partial_charge(charge);
       },
       rvp::automatic,
@@ -1025,8 +1020,9 @@ The name of the atom. Returns an empty string if the name is not set.
         if (hyb)
           *hyb = get_or_throw_hyb(*hyb);
 
-        if (implicit_hydrogens)
-          *implicit_hydrogens = check_implicit_hydrogens(*implicit_hydrogens);
+        check_positive(implicit_hydrogens, "implicit_hydrogens",
+                       Bounds::kClosed);
+        check_finite(partial_charge, "partial_charge");
 
         if (atomic_number && element != nullptr)
           throw py::value_error(

--- a/python/include/nuri/python/core/core_module.h
+++ b/python/include/nuri/python/core/core_module.h
@@ -730,7 +730,7 @@ The hybridization of the atom.
       "implicit_hydrogens",
       [](T &self) { return atom_prolog(self).implicit_hydrogens(); },
       [](T &self, int n) {
-        check_positive(n, "implicit_hydrogens", Bounds::kClosed);
+        check_interval(n, "implicit_hydrogens", Bounds::kClosed, 0);
         atom_prolog(self).set_implicit_hydrogens(n);
       },
       rvp::automatic,
@@ -1020,8 +1020,8 @@ The name of the atom. Returns an empty string if the name is not set.
         if (hyb)
           *hyb = get_or_throw_hyb(*hyb);
 
-        check_positive(implicit_hydrogens, "implicit_hydrogens",
-                       Bounds::kClosed);
+        check_interval(implicit_hydrogens, "implicit_hydrogens",
+                       Bounds::kClosed, 0);
         check_finite(partial_charge, "partial_charge");
 
         if (atomic_number && element != nullptr)

--- a/python/include/nuri/python/utils.h
+++ b/python/include/nuri/python/utils.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <optional>
 #include <stdexcept>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -23,6 +24,7 @@
 #include <absl/log/absl_check.h>
 #include <absl/log/absl_log.h>
 #include <absl/strings/str_cat.h>
+#include <boost/type_traits/type_identity.hpp>
 #include <Eigen/Dense>
 #include <pybind11/attr.h>
 #include <pybind11/eigen.h>
@@ -36,24 +38,12 @@
 #include "nuri/utils.h"
 
 namespace nuri {
-namespace internal {
-// Which ends of a check_interval() range are exclusive
-enum class Bounds : std::uint8_t {
-  kClosed = 0x0,
-  kOpenLo = 0x1,
-  kOpenHi = 0x2,
-  kOpen = 0x3,
-};
-}  // namespace internal
-
 namespace python_internal {
-using internal::Bounds;
-
 template <class CppType, class... Args>
 using PyProxyCls =
     py::class_<CppType, std::unique_ptr<CppType, py::nodelete>, Args...>;
 
-inline double check_finite(double x, const char *what = "value") {
+inline double check_finite(double x, std::string_view what = "value") {
   if (!std::isfinite(x))
     throw py::value_error(
         absl::StrCat("expected a finite ", what, ", got ", x));
@@ -61,52 +51,64 @@ inline double check_finite(double x, const char *what = "value") {
 }
 
 inline std::optional<double> check_finite(std::optional<double> x,
-                                          const char *what = "value") {
+                                          std::string_view what = "value") {
   if (x)
     check_finite(*x, what);
   return x;
 }
 
-// Blocks deduction so bound literals convert to T instead of fixing it
-template <class T>
-struct NoDeduce {
-  using type = T;
+enum class Bounds : std::uint8_t {
+  kClosed = 0x0,
+  kLeftOpen = 0x1,
+  kRightOpen = 0x2,
+  kOpen = kLeftOpen | kRightOpen,
 };
-
-template <class T>
-using NoDeduceT = typename NoDeduce<T>::type;
 
 /**
  * Reject @p v unless it lies in the interval [@p lo, @p hi], where an absent
  * bound means unbounded and @p b selects which ends are exclusive.
  */
 template <class T>
-T check_interval(T v, const char *what, Bounds b,
-                 std::optional<NoDeduceT<T>> lo = {},
-                 std::optional<NoDeduceT<T>> hi = {}) {
+T check_interval(T v, std::string_view what, Bounds b,
+                 std::optional<boost::type_identity_t<T>> lo = std::nullopt,
+                 std::optional<boost::type_identity_t<T>> hi = std::nullopt) {
   if constexpr (std::is_floating_point_v<T>)
     check_finite(v, what);
 
-  const bool open_lo = internal::check_flag(b, Bounds::kOpenLo);
-  const bool open_hi = internal::check_flag(b, Bounds::kOpenHi);
+  const bool open_lo = internal::check_flag(b, Bounds::kLeftOpen) || !lo;
+  const bool open_hi = internal::check_flag(b, Bounds::kRightOpen) || !hi;
 
   if ((!lo || (open_lo ? v > *lo : v >= *lo))
       && (!hi || (open_hi ? v < *hi : v <= *hi)))
     return v;
 
+  constexpr std::string_view lefts[] { "[", "(" };
+  constexpr std::string_view rights[] { "]", ")" };
+
   throw py::value_error(absl::StrCat(
-      what, " must be in ", open_lo || !lo ? "(" : "[",
+      what, " must be in ", lefts[value_if(open_lo)],
       lo ? absl::StrCat(*lo) : "-inf", ", ", hi ? absl::StrCat(*hi) : "inf",
-      open_hi || !hi ? ")" : "]", ", got ", v));
+      rights[value_if(open_hi)], ", got ", v));
 }
 
 template <class T>
-std::optional<T> check_interval(std::optional<T> v, const char *what, Bounds b,
-                                std::optional<NoDeduceT<T>> lo = {},
-                                std::optional<NoDeduceT<T>> hi = {}) {
+std::optional<T>
+check_interval(std::optional<T> v, std::string_view what, Bounds b,
+               std::optional<boost::type_identity_t<T>> lo = std::nullopt,
+               std::optional<boost::type_identity_t<T>> hi = std::nullopt) {
   if (v)
     check_interval(*v, what, b, lo, hi);
   return v;
+}
+
+template <class T>
+T check_nonneg(T v, std::string_view what) {
+  return check_interval(v, what, Bounds::kClosed, 0);
+}
+
+template <class T>
+T check_positive(T v, std::string_view what) {
+  return check_interval(v, what, Bounds::kLeftOpen, 0);
 }
 
 template <class Derived, class T>

--- a/python/include/nuri/python/utils.h
+++ b/python/include/nuri/python/utils.h
@@ -55,8 +55,6 @@ inline std::optional<double> check_finite(std::optional<double> x,
   return x;
 }
 
-// Selects whether the lower bound is inclusive (kClosed) or exclusive
-// (kLeftOpen). The upper bound of check_interval() is always inclusive.
 enum class Bounds { kClosed, kLeftOpen };
 
 template <class T>
@@ -87,10 +85,10 @@ T check_interval(T v, T lo, T hi, const char *what,
   if constexpr (std::is_floating_point_v<T>)
     check_finite(v, what);
 
-  const bool lo_ok = b == Bounds::kClosed ? v >= lo : v > lo;
-  if (!lo_ok || v > hi) {
-    throw py::value_error(
-        absl::StrCat(what, " must be between ", lo, " and ", hi, ", got ", v));
+  const bool open = b == Bounds::kLeftOpen;
+  if ((open ? v <= lo : v < lo) || v > hi) {
+    throw py::value_error(absl::StrCat(what, " must be in ", open ? "(" : "[",
+                                       lo, ", ", hi, "], got ", v));
   }
   return v;
 }

--- a/python/include/nuri/python/utils.h
+++ b/python/include/nuri/python/utils.h
@@ -7,9 +7,11 @@
 #define NURI_PYTHON_UTILS_H_
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -38,6 +40,68 @@ namespace python_internal {
 template <class CppType, class... Args>
 using PyProxyCls =
     py::class_<CppType, std::unique_ptr<CppType, py::nodelete>, Args...>;
+
+inline double check_finite(double x, const char *what = "value") {
+  if (!std::isfinite(x))
+    throw py::value_error(
+        absl::StrCat("expected a finite ", what, ", got ", x));
+  return x;
+}
+
+inline std::optional<double> check_finite(std::optional<double> x,
+                                          const char *what = "value") {
+  if (x)
+    check_finite(*x, what);
+  return x;
+}
+
+// Selects whether the lower bound is inclusive (kClosed) or exclusive
+// (kLeftOpen). The upper bound of check_interval() is always inclusive.
+enum class Bounds { kClosed, kLeftOpen };
+
+template <class T>
+T check_positive(T v, const char *what, Bounds b = Bounds::kLeftOpen) {
+  if constexpr (std::is_floating_point_v<T>)
+    check_finite(v, what);
+
+  const bool open = b == Bounds::kLeftOpen;
+  if (open ? v <= 0 : v < 0) {
+    throw py::value_error(absl::StrCat(
+        what, open ? " must be positive, got " : " must be non-negative, got ",
+        v));
+  }
+  return v;
+}
+
+template <class T>
+std::optional<T> check_positive(std::optional<T> v, const char *what,
+                                Bounds b = Bounds::kLeftOpen) {
+  if (v)
+    check_positive(*v, what, b);
+  return v;
+}
+
+template <class T>
+T check_interval(T v, T lo, T hi, const char *what,
+                 Bounds b = Bounds::kClosed) {
+  if constexpr (std::is_floating_point_v<T>)
+    check_finite(v, what);
+
+  const bool lo_ok = b == Bounds::kClosed ? v >= lo : v > lo;
+  if (!lo_ok || v > hi) {
+    throw py::value_error(
+        absl::StrCat(what, " must be between ", lo, " and ", hi, ", got ", v));
+  }
+  return v;
+}
+
+template <class T>
+std::optional<T> check_interval(std::optional<T> v, T lo, T hi,
+                                const char *what, Bounds b = Bounds::kClosed) {
+  if (v)
+    check_interval(*v, lo, hi, what, b);
+  return v;
+}
 
 template <class Derived, class T>
 class ParentWrapper {
@@ -428,6 +492,13 @@ private:
     }
   }
 
+  void check_finite() const {
+    if constexpr (std::is_floating_point_v<DT>) {
+      if (!eigen().allFinite())
+        throw py::value_error("NaN or infinite values in array");
+    }
+  }
+
   template <Eigen::Index R, Eigen::Index C, class DU>
   friend NpArrayWrapper<R, C, DU>
   empty_numpy(std::vector<py::ssize_t> &&eigen_shape);
@@ -476,9 +547,12 @@ NpArrayWrapper<Rows, Cols, DT> py_array_cast(py::handle h) {
   broadcast_if_compatible<Rows, Cols, DT>(arr);
   numpy_to_eigen_check_compat<Rows, Cols, DT>(arr);
 
-  auto maybe_copy = [&arr](Eigen::Index rows, Eigen::Index cols, auto strides) {
-    if (strides.inner() == 1)
-      return NpArrayWrapper<Rows, Cols, DT> { std::move(arr) };
+  auto finalize = [&arr](Eigen::Index rows, Eigen::Index cols, auto strides) {
+    if (strides.inner() == 1) {
+      NpArrayWrapper<Rows, Cols, DT> wrapper(std::move(arr));
+      wrapper.check_finite();
+      return wrapper;
+    }
 
     ABSL_DLOG(INFO) << "copy triggered";
 
@@ -487,6 +561,7 @@ NpArrayWrapper<Rows, Cols, DT> py_array_cast(py::handle h) {
 
     auto wrapper = empty_like(data);
     wrapper.eigen() = data;
+    wrapper.check_finite();
     return wrapper;
   };
 
@@ -499,12 +574,11 @@ NpArrayWrapper<Rows, Cols, DT> py_array_cast(py::handle h) {
       rows = 1;
       cols = arr.size();
     }
-    return maybe_copy(rows, cols,
-                      Eigen::InnerStride<> { eigen_stride(arr, 0) });
+    return finalize(rows, cols, Eigen::InnerStride<> { eigen_stride(arr, 0) });
   } else {
-    return maybe_copy(arr.shape()[1], arr.shape()[0],
-                      py::EigenDStride { eigen_stride(arr, 0),
-                                         eigen_stride(arr, 1) });
+    return finalize(arr.shape()[1], arr.shape()[0],
+                    py::EigenDStride { eigen_stride(arr, 0),
+                                       eigen_stride(arr, 1) });
   }
 }
 

--- a/python/include/nuri/python/utils.h
+++ b/python/include/nuri/python/utils.h
@@ -57,47 +57,42 @@ inline std::optional<double> check_finite(std::optional<double> x,
 
 enum class Bounds { kClosed, kLeftOpen };
 
+// Blocks deduction so bound literals convert to T instead of fixing it
 template <class T>
-T check_positive(T v, const char *what, Bounds b = Bounds::kLeftOpen) {
+struct NoDeduce {
+  using type = T;
+};
+
+template <class T>
+using NoDeduceT = typename NoDeduce<T>::type;
+
+/**
+ * Reject @p v unless it lies in the interval [@p lo, @p hi], where an absent
+ * bound means unbounded and @p b selects whether @p lo itself is allowed.
+ */
+template <class T>
+T check_interval(T v, const char *what, Bounds b,
+                 std::optional<NoDeduceT<T>> lo = {},
+                 std::optional<NoDeduceT<T>> hi = {}) {
   if constexpr (std::is_floating_point_v<T>)
     check_finite(v, what);
 
   const bool open = b == Bounds::kLeftOpen;
-  if (open ? v <= 0 : v < 0) {
-    throw py::value_error(absl::StrCat(
-        what, open ? " must be positive, got " : " must be non-negative, got ",
-        v));
-  }
-  return v;
+  if ((!lo || (open ? v > *lo : v >= *lo)) && (!hi || v <= *hi))
+    return v;
+
+  throw py::value_error(absl::StrCat(
+      what, " must be in ", open || !lo ? "(" : "[",
+      lo ? absl::StrCat(*lo) : "-inf", ", ", hi ? absl::StrCat(*hi) : "inf",
+      hi ? "], got " : "), got ", v));
 }
 
 template <class T>
-std::optional<T> check_positive(std::optional<T> v, const char *what,
-                                Bounds b = Bounds::kLeftOpen) {
+std::optional<T> check_interval(std::optional<T> v, const char *what, Bounds b,
+                                std::optional<NoDeduceT<T>> lo = {},
+                                std::optional<NoDeduceT<T>> hi = {}) {
   if (v)
-    check_positive(*v, what, b);
-  return v;
-}
-
-template <class T>
-T check_interval(T v, T lo, T hi, const char *what,
-                 Bounds b = Bounds::kClosed) {
-  if constexpr (std::is_floating_point_v<T>)
-    check_finite(v, what);
-
-  const bool open = b == Bounds::kLeftOpen;
-  if ((open ? v <= lo : v < lo) || v > hi) {
-    throw py::value_error(absl::StrCat(what, " must be in ", open ? "(" : "[",
-                                       lo, ", ", hi, "], got ", v));
-  }
-  return v;
-}
-
-template <class T>
-std::optional<T> check_interval(std::optional<T> v, T lo, T hi,
-                                const char *what, Bounds b = Bounds::kClosed) {
-  if (v)
-    check_interval(*v, lo, hi, what, b);
+    check_interval(*v, what, b, lo, hi);
   return v;
 }
 

--- a/python/include/nuri/python/utils.h
+++ b/python/include/nuri/python/utils.h
@@ -36,7 +36,19 @@
 #include "nuri/utils.h"
 
 namespace nuri {
+namespace internal {
+// Which ends of a check_interval() range are exclusive
+enum class Bounds : std::uint8_t {
+  kClosed = 0x0,
+  kOpenLo = 0x1,
+  kOpenHi = 0x2,
+  kOpen = 0x3,
+};
+}  // namespace internal
+
 namespace python_internal {
+using internal::Bounds;
+
 template <class CppType, class... Args>
 using PyProxyCls =
     py::class_<CppType, std::unique_ptr<CppType, py::nodelete>, Args...>;
@@ -55,8 +67,6 @@ inline std::optional<double> check_finite(std::optional<double> x,
   return x;
 }
 
-enum class Bounds { kClosed, kLeftOpen };
-
 // Blocks deduction so bound literals convert to T instead of fixing it
 template <class T>
 struct NoDeduce {
@@ -68,7 +78,7 @@ using NoDeduceT = typename NoDeduce<T>::type;
 
 /**
  * Reject @p v unless it lies in the interval [@p lo, @p hi], where an absent
- * bound means unbounded and @p b selects whether @p lo itself is allowed.
+ * bound means unbounded and @p b selects which ends are exclusive.
  */
 template <class T>
 T check_interval(T v, const char *what, Bounds b,
@@ -77,14 +87,17 @@ T check_interval(T v, const char *what, Bounds b,
   if constexpr (std::is_floating_point_v<T>)
     check_finite(v, what);
 
-  const bool open = b == Bounds::kLeftOpen;
-  if ((!lo || (open ? v > *lo : v >= *lo)) && (!hi || v <= *hi))
+  const bool open_lo = internal::check_flag(b, Bounds::kOpenLo);
+  const bool open_hi = internal::check_flag(b, Bounds::kOpenHi);
+
+  if ((!lo || (open_lo ? v > *lo : v >= *lo))
+      && (!hi || (open_hi ? v < *hi : v <= *hi)))
     return v;
 
   throw py::value_error(absl::StrCat(
-      what, " must be in ", open || !lo ? "(" : "[",
+      what, " must be in ", open_lo || !lo ? "(" : "[",
       lo ? absl::StrCat(*lo) : "-inf", ", ", hi ? absl::StrCat(*hi) : "inf",
-      hi ? "], got " : "), got ", v));
+      open_hi || !hi ? ")" : "]", ", got ", v));
 }
 
 template <class T>

--- a/python/src/nuri/algo/algo_module.cpp
+++ b/python/src/nuri/algo/algo_module.cpp
@@ -24,7 +24,7 @@ namespace nuri {
 namespace python_internal {
 namespace {
 int check_size(std::optional<int> size) {
-  return check_interval(size, "max_size", Bounds::kOpenLo, 0).value_or(-1);
+  return check_positive(size, "max_size").value_or(-1);
 }
 
 template <class AtomIndexer>
@@ -230,7 +230,7 @@ void bind_guess(py::module_ &m) {
   m.def(
        "guess_everything",
        [](PyMutator &mut, int conf, double threshold) {
-         check_interval(threshold, "threshold", Bounds::kClosed, 0);
+         check_nonneg(threshold, "threshold");
          conf = check_conf(mut.mol(), conf);
          bool success = guess_everything(mut.mut(), conf, threshold);
          if (!success)
@@ -266,7 +266,7 @@ efficient.
       .def(
           "guess_connectivity",
           [](PyMutator &mut, int conf, double threshold) {
-            check_interval(threshold, "threshold", Bounds::kClosed, 0);
+            check_nonneg(threshold, "threshold");
             conf = check_conf(mut.mol(), conf);
             guess_connectivity(mut.mut(), conf, threshold);
           },
@@ -324,7 +324,7 @@ void bind_crdgen(py::module_ &m) {
         if (absl::AsciiStrToUpper(method) != "DG")
           throw py::value_error(absl::StrCat("Unsupported method: ", method));
 
-        check_interval(trial, "max_trial", Bounds::kOpenLo, 0);
+        check_positive(trial, "max_trial");
 
         bool success = generate_coords(*mol, trial);
         if (!success)

--- a/python/src/nuri/algo/algo_module.cpp
+++ b/python/src/nuri/algo/algo_module.cpp
@@ -24,7 +24,7 @@ namespace nuri {
 namespace python_internal {
 namespace {
 int check_size(std::optional<int> size) {
-  return check_interval(size, "max_size", Bounds::kLeftOpen, 0).value_or(-1);
+  return check_interval(size, "max_size", Bounds::kOpenLo, 0).value_or(-1);
 }
 
 template <class AtomIndexer>
@@ -324,7 +324,7 @@ void bind_crdgen(py::module_ &m) {
         if (absl::AsciiStrToUpper(method) != "DG")
           throw py::value_error(absl::StrCat("Unsupported method: ", method));
 
-        check_interval(trial, "max_trial", Bounds::kLeftOpen, 0);
+        check_interval(trial, "max_trial", Bounds::kOpenLo, 0);
 
         bool success = generate_coords(*mol, trial);
         if (!success)

--- a/python/src/nuri/algo/algo_module.cpp
+++ b/python/src/nuri/algo/algo_module.cpp
@@ -24,10 +24,7 @@ namespace nuri {
 namespace python_internal {
 namespace {
 int check_size(std::optional<int> size) {
-  if (size && *size <= 0)
-    throw py::value_error("max_size must be positive number");
-
-  return size.value_or(-1);
+  return check_positive(size, "max_size").value_or(-1);
 }
 
 template <class AtomIndexer>
@@ -233,6 +230,7 @@ void bind_guess(py::module_ &m) {
   m.def(
        "guess_everything",
        [](PyMutator &mut, int conf, double threshold) {
+         check_positive(threshold, "threshold", Bounds::kClosed);
          conf = check_conf(mut.mol(), conf);
          bool success = guess_everything(mut.mut(), conf, threshold);
          if (!success)
@@ -268,6 +266,7 @@ efficient.
       .def(
           "guess_connectivity",
           [](PyMutator &mut, int conf, double threshold) {
+            check_positive(threshold, "threshold", Bounds::kClosed);
             conf = check_conf(mut.mol(), conf);
             guess_connectivity(mut.mut(), conf, threshold);
           },
@@ -324,6 +323,8 @@ void bind_crdgen(py::module_ &m) {
       [](PyMol &mol, std::string_view method, int trial) {
         if (absl::AsciiStrToUpper(method) != "DG")
           throw py::value_error(absl::StrCat("Unsupported method: ", method));
+
+        check_positive(trial, "max_trial");
 
         bool success = generate_coords(*mol, trial);
         if (!success)

--- a/python/src/nuri/algo/algo_module.cpp
+++ b/python/src/nuri/algo/algo_module.cpp
@@ -24,7 +24,7 @@ namespace nuri {
 namespace python_internal {
 namespace {
 int check_size(std::optional<int> size) {
-  return check_positive(size, "max_size").value_or(-1);
+  return check_interval(size, "max_size", Bounds::kLeftOpen, 0).value_or(-1);
 }
 
 template <class AtomIndexer>
@@ -230,7 +230,7 @@ void bind_guess(py::module_ &m) {
   m.def(
        "guess_everything",
        [](PyMutator &mut, int conf, double threshold) {
-         check_positive(threshold, "threshold", Bounds::kClosed);
+         check_interval(threshold, "threshold", Bounds::kClosed, 0);
          conf = check_conf(mut.mol(), conf);
          bool success = guess_everything(mut.mut(), conf, threshold);
          if (!success)
@@ -266,7 +266,7 @@ efficient.
       .def(
           "guess_connectivity",
           [](PyMutator &mut, int conf, double threshold) {
-            check_positive(threshold, "threshold", Bounds::kClosed);
+            check_interval(threshold, "threshold", Bounds::kClosed, 0);
             conf = check_conf(mut.mol(), conf);
             guess_connectivity(mut.mut(), conf, threshold);
           },
@@ -324,7 +324,7 @@ void bind_crdgen(py::module_ &m) {
         if (absl::AsciiStrToUpper(method) != "DG")
           throw py::value_error(absl::StrCat("Unsupported method: ", method));
 
-        check_positive(trial, "max_trial");
+        check_interval(trial, "max_trial", Bounds::kLeftOpen, 0);
 
         bool success = generate_coords(*mol, trial);
         if (!success)

--- a/python/src/nuri/core/geometry.cpp
+++ b/python/src/nuri/core/geometry.cpp
@@ -274,7 +274,7 @@ To update the point set, one must :py:meth:`rebuild()` the octree.
 )doc")
       .def(py::init([](const py::handle &obj, int bucket_size) {
              auto py_arr = py_array_cast<3>(obj);
-             check_positive(bucket_size, "bucket size");
+             check_interval(bucket_size, "bucket size", Bounds::kLeftOpen, 0);
              OCTreeWrapper self { OCTree(), py_arr.eigen() };
              self.tree.rebuild(self.pts, bucket_size);
              return self;
@@ -293,7 +293,7 @@ Initialize the octree with a set of points.
           "rebuild",
           [](OCTreeWrapper &self, const py::handle &obj, int bucket_size) {
             auto py_arr = py_array_cast<3>(obj);
-            check_positive(bucket_size, "bucket size");
+            check_interval(bucket_size, "bucket size", Bounds::kLeftOpen, 0);
             self.pts = py_arr.eigen();
             self.tree.rebuild(self.pts, bucket_size);
           },
@@ -317,8 +317,8 @@ Rebuild the octree with a new set of points.
                   "either cutoff distance or number of neighbors must be "
                   "specified");
             }
-            check_positive(xd, "cutoff");
-            check_positive(xk, "number of neighbors");
+            check_interval(xd, "cutoff", Bounds::kLeftOpen, 0);
+            check_interval(xk, "number of neighbors", Bounds::kLeftOpen, 0);
 
             void (*impl)(const OCTree &, const Vector3d &, double, int,
                          std::vector<int> &, std::vector<double> &);
@@ -390,7 +390,7 @@ Find neighbors of each point in the octree.
           "query_tree",
           [](const OCTreeWrapper &self, const OCTreeWrapper &other,
              double d) -> pyt::List<py::array_t<int>> {
-            check_positive(d, "cutoff");
+            check_interval(d, "cutoff", Bounds::kLeftOpen, 0);
 
             std::vector<std::vector<int>> idxs =
                 self.tree.find_neighbors_tree(other.tree, d);
@@ -419,7 +419,7 @@ Find all neighbors in another octree.
       .def(
           "query_pairs",
           [](const OCTreeWrapper &self, double d) {
-            check_positive(d, "cutoff");
+            check_interval(d, "cutoff", Bounds::kLeftOpen, 0);
 
             std::vector<int> is, js;
             self.tree.find_neighbors_self(d, is, js);
@@ -452,7 +452,7 @@ The voxel grid partitions 3D space into uniform cells, allowing efficient
 distance queries with the cutoff specified at construction time.
 )doc")
       .def(py::init([](const py::handle &obj, double cutoff) {
-             check_positive(cutoff, "cutoff");
+             check_interval(cutoff, "cutoff", Bounds::kLeftOpen, 0);
 
              auto py_arr = py_array_cast<3>(obj);
 
@@ -477,7 +477,7 @@ Initialize the voxel grid with a set of points and cutoff distance.
             double cutoff = self.cutoff();
             if (xcutoff) {
               cutoff = *xcutoff;
-              check_positive(cutoff, "cutoff");
+              check_interval(cutoff, "cutoff", Bounds::kLeftOpen, 0);
             }
 
             auto py_arr = py_array_cast<3>(obj);

--- a/python/src/nuri/core/geometry.cpp
+++ b/python/src/nuri/core/geometry.cpp
@@ -70,9 +70,6 @@ check_convert_points(const NpArrayWrapper<3> &q_arr,
                      query.cols(), " and ", templ.cols()));
   }
 
-  if (!query.array().isFinite().all() || !templ.array().isFinite().all())
-    throw py::value_error("NaN or infinite values in the points");
-
   return { query, templ };
 }
 
@@ -90,13 +87,6 @@ template <class T>
 auto vector_as_eigen(const std::vector<T> &v) {
   return E::Map<const E::Array<T, E::Dynamic, 1>>(
       v.data(), static_cast<E::Index>(v.size()));
-}
-
-void check_cutoff(double cutoff) {
-  if (!(cutoff > 0)) {
-    throw py::value_error(
-        absl::StrCat("cutoff distance must be positive; got ", cutoff));
-  }
 }
 
 void find_neighbors_d(const OCTree &octree, const Vector3d &query, double d,
@@ -260,6 +250,7 @@ To update the point set, one must :py:meth:`rebuild()` the octree.
 )doc")
       .def(py::init([](const py::handle &obj, int bucket_size) {
              auto py_arr = py_array_cast<3>(obj);
+             check_positive(bucket_size, "bucket size");
              OCTreeWrapper self { OCTree(), py_arr.eigen() };
              self.tree.rebuild(self.pts, bucket_size);
              return self;
@@ -276,6 +267,7 @@ Initialize the octree with a set of points.
           "rebuild",
           [](OCTreeWrapper &self, const py::handle &obj, int bucket_size) {
             auto py_arr = py_array_cast<3>(obj);
+            check_positive(bucket_size, "bucket size");
             self.pts = py_arr.eigen();
             self.tree.rebuild(self.pts, bucket_size);
           },
@@ -297,6 +289,8 @@ Rebuild the octree with a new set of points.
                   "either cutoff distance or number of neighbors must be "
                   "specified");
             }
+            check_positive(xd, "cutoff");
+            check_positive(xk, "number of neighbors");
 
             void (*impl)(const OCTree &, const Vector3d &, double, int,
                          std::vector<int> &, std::vector<double> &);
@@ -365,7 +359,7 @@ Find neighbors of each point in the octree.
           "query_tree",
           [](const OCTreeWrapper &self, const OCTreeWrapper &other,
              double d) -> pyt::List<py::array_t<int>> {
-            check_cutoff(d);
+            check_positive(d, "cutoff");
 
             std::vector<std::vector<int>> idxs =
                 self.tree.find_neighbors_tree(other.tree, d);
@@ -392,7 +386,7 @@ Find all neighbors in another octree.
       .def(
           "query_pairs",
           [](const OCTreeWrapper &self, double d) {
-            check_cutoff(d);
+            check_positive(d, "cutoff");
 
             std::vector<int> is, js;
             self.tree.find_neighbors_self(d, is, js);
@@ -423,7 +417,7 @@ The voxel grid partitions 3D space into uniform cells, allowing efficient
 distance queries with the cutoff specified at construction time.
 )doc")
       .def(py::init([](const py::handle &obj, double cutoff) {
-             check_cutoff(cutoff);
+             check_positive(cutoff, "cutoff");
 
              auto py_arr = py_array_cast<3>(obj);
              return VoxelGrid(py_arr.eigen(), cutoff);
@@ -442,7 +436,7 @@ Initialize the voxel grid with a set of points and cutoff distance.
             double cutoff = -1.0;
             if (xcutoff) {
               cutoff = *xcutoff;
-              check_cutoff(cutoff);
+              check_positive(cutoff, "cutoff");
             }
 
             auto py_arr = py_array_cast<3>(obj);

--- a/python/src/nuri/core/geometry.cpp
+++ b/python/src/nuri/core/geometry.cpp
@@ -249,8 +249,9 @@ Effectively, this function is roughly equivalent to the following Python code:
   of shape ``(N, 3)``.
 :returns: The transformed points.
 
-:warning: This function does not check if the transformation tensor is a valid
-  affine transformation matrix.
+.. warning::
+  This function does not check if the transformation tensor is a valid affine
+  transformation matrix.
 )doc");
 
   py::class_<OCTreeWrapper>(m, "Octree", R"doc(

--- a/python/src/nuri/core/geometry.cpp
+++ b/python/src/nuri/core/geometry.cpp
@@ -274,7 +274,7 @@ To update the point set, one must :py:meth:`rebuild()` the octree.
 )doc")
       .def(py::init([](const py::handle &obj, int bucket_size) {
              auto py_arr = py_array_cast<3>(obj);
-             check_interval(bucket_size, "bucket_size", Bounds::kLeftOpen, 0);
+             check_interval(bucket_size, "bucket_size", Bounds::kOpenLo, 0);
              OCTreeWrapper self { OCTree(), py_arr.eigen() };
              self.tree.rebuild(self.pts, bucket_size);
              return self;
@@ -293,7 +293,7 @@ Initialize the octree with a set of points.
           "rebuild",
           [](OCTreeWrapper &self, const py::handle &obj, int bucket_size) {
             auto py_arr = py_array_cast<3>(obj);
-            check_interval(bucket_size, "bucket_size", Bounds::kLeftOpen, 0);
+            check_interval(bucket_size, "bucket_size", Bounds::kOpenLo, 0);
             self.pts = py_arr.eigen();
             self.tree.rebuild(self.pts, bucket_size);
           },
@@ -317,8 +317,8 @@ Rebuild the octree with a new set of points.
                   "either cutoff distance or number of neighbors must be "
                   "specified");
             }
-            check_interval(xd, "d", Bounds::kLeftOpen, 0);
-            check_interval(xk, "k", Bounds::kLeftOpen, 0);
+            check_interval(xd, "d", Bounds::kOpenLo, 0);
+            check_interval(xk, "k", Bounds::kOpenLo, 0);
 
             void (*impl)(const OCTree &, const Vector3d &, double, int,
                          std::vector<int> &, std::vector<double> &);
@@ -390,7 +390,7 @@ Find neighbors of each point in the octree.
           "query_tree",
           [](const OCTreeWrapper &self, const OCTreeWrapper &other,
              double d) -> pyt::List<py::array_t<int>> {
-            check_interval(d, "d", Bounds::kLeftOpen, 0);
+            check_interval(d, "d", Bounds::kOpenLo, 0);
 
             std::vector<std::vector<int>> idxs =
                 self.tree.find_neighbors_tree(other.tree, d);
@@ -419,7 +419,7 @@ Find all neighbors in another octree.
       .def(
           "query_pairs",
           [](const OCTreeWrapper &self, double d) {
-            check_interval(d, "d", Bounds::kLeftOpen, 0);
+            check_interval(d, "d", Bounds::kOpenLo, 0);
 
             std::vector<int> is, js;
             self.tree.find_neighbors_self(d, is, js);
@@ -452,7 +452,7 @@ The voxel grid partitions 3D space into uniform cells, allowing efficient
 distance queries with the cutoff specified at construction time.
 )doc")
       .def(py::init([](const py::handle &obj, double cutoff) {
-             check_interval(cutoff, "cutoff", Bounds::kLeftOpen, 0);
+             check_interval(cutoff, "cutoff", Bounds::kOpenLo, 0);
 
              auto py_arr = py_array_cast<3>(obj);
 
@@ -477,7 +477,7 @@ Initialize the voxel grid with a set of points and cutoff distance.
             double cutoff = self.cutoff();
             if (xcutoff) {
               cutoff = *xcutoff;
-              check_interval(cutoff, "cutoff", Bounds::kLeftOpen, 0);
+              check_interval(cutoff, "cutoff", Bounds::kOpenLo, 0);
             }
 
             auto py_arr = py_array_cast<3>(obj);

--- a/python/src/nuri/core/geometry.cpp
+++ b/python/src/nuri/core/geometry.cpp
@@ -274,7 +274,7 @@ To update the point set, one must :py:meth:`rebuild()` the octree.
 )doc")
       .def(py::init([](const py::handle &obj, int bucket_size) {
              auto py_arr = py_array_cast<3>(obj);
-             check_interval(bucket_size, "bucket size", Bounds::kLeftOpen, 0);
+             check_interval(bucket_size, "bucket_size", Bounds::kLeftOpen, 0);
              OCTreeWrapper self { OCTree(), py_arr.eigen() };
              self.tree.rebuild(self.pts, bucket_size);
              return self;
@@ -293,7 +293,7 @@ Initialize the octree with a set of points.
           "rebuild",
           [](OCTreeWrapper &self, const py::handle &obj, int bucket_size) {
             auto py_arr = py_array_cast<3>(obj);
-            check_interval(bucket_size, "bucket size", Bounds::kLeftOpen, 0);
+            check_interval(bucket_size, "bucket_size", Bounds::kLeftOpen, 0);
             self.pts = py_arr.eigen();
             self.tree.rebuild(self.pts, bucket_size);
           },
@@ -317,8 +317,8 @@ Rebuild the octree with a new set of points.
                   "either cutoff distance or number of neighbors must be "
                   "specified");
             }
-            check_interval(xd, "cutoff", Bounds::kLeftOpen, 0);
-            check_interval(xk, "number of neighbors", Bounds::kLeftOpen, 0);
+            check_interval(xd, "d", Bounds::kLeftOpen, 0);
+            check_interval(xk, "k", Bounds::kLeftOpen, 0);
 
             void (*impl)(const OCTree &, const Vector3d &, double, int,
                          std::vector<int> &, std::vector<double> &);
@@ -390,7 +390,7 @@ Find neighbors of each point in the octree.
           "query_tree",
           [](const OCTreeWrapper &self, const OCTreeWrapper &other,
              double d) -> pyt::List<py::array_t<int>> {
-            check_interval(d, "cutoff", Bounds::kLeftOpen, 0);
+            check_interval(d, "d", Bounds::kLeftOpen, 0);
 
             std::vector<std::vector<int>> idxs =
                 self.tree.find_neighbors_tree(other.tree, d);
@@ -419,7 +419,7 @@ Find all neighbors in another octree.
       .def(
           "query_pairs",
           [](const OCTreeWrapper &self, double d) {
-            check_interval(d, "cutoff", Bounds::kLeftOpen, 0);
+            check_interval(d, "d", Bounds::kLeftOpen, 0);
 
             std::vector<int> is, js;
             self.tree.find_neighbors_self(d, is, js);

--- a/python/src/nuri/core/geometry.cpp
+++ b/python/src/nuri/core/geometry.cpp
@@ -100,6 +100,14 @@ void find_neighbors_kd(const OCTree &octree, const Vector3d &query, double d,
                        std::vector<double> &distsq) {
   octree.find_neighbors_kd(query, k, idxs, distsq, d);
 }
+
+void check_cutoff_honored(const VoxelGrid &grid, double cutoff) {
+  if (grid.cutoff() > cutoff) {
+    throw py::value_error(absl::StrCat(
+        "cutoff is too small for the given points and would be widened to ",
+        grid.cutoff()));
+  }
+}
 }  // namespace
 
 void bind_geometry(py::module &m) {
@@ -447,7 +455,10 @@ distance queries with the cutoff specified at construction time.
              check_positive(cutoff, "cutoff");
 
              auto py_arr = py_array_cast<3>(obj);
-             return VoxelGrid(py_arr.eigen(), cutoff);
+
+             VoxelGrid grid(py_arr.eigen(), cutoff);
+             check_cutoff_honored(grid, cutoff);
+             return grid;
            }),
            py::arg("pts"), py::arg("cutoff"), R"doc(
 Initialize the voxel grid with a set of points and cutoff distance.
@@ -456,20 +467,25 @@ Initialize the voxel grid with a set of points and cutoff distance.
   numpy array of shape ``(N, 3)``.
 :param cutoff: The cutoff distance for neighbor queries. Must be positive.
 
-:raises ValueError: If ``cutoff`` is not positive.
+:raises ValueError: If ``cutoff`` is not positive, or is so small that the
+  points would need too many voxels to index.
 )doc")
       .def(
           "rebuild",
           [](VoxelGrid &self, const py::handle &obj,
              std::optional<double> xcutoff) {
-            double cutoff = -1.0;
+            double cutoff = self.cutoff();
             if (xcutoff) {
               cutoff = *xcutoff;
               check_positive(cutoff, "cutoff");
             }
 
             auto py_arr = py_array_cast<3>(obj);
-            self.rebuild(py_arr.eigen(), cutoff);
+
+            // Built aside so a rejected cutoff leaves self untouched
+            VoxelGrid grid(py_arr.eigen(), cutoff);
+            check_cutoff_honored(grid, cutoff);
+            self = std::move(grid);
           },
           py::arg("pts"), py::arg("cutoff") = py::none(), R"doc(
 Rebuild the voxel grid with a new set of points.
@@ -479,7 +495,9 @@ Rebuild the voxel grid with a new set of points.
 :param cutoff: The cutoff distance for neighbor queries. If omitted, the
   current cutoff is reused. Must be positive when specified.
 
-:raises ValueError: If ``cutoff`` is specified and not positive.
+:raises ValueError: If ``cutoff`` is specified and not positive, or if the
+  points would need too many voxels to index at the effective cutoff. The grid
+  is left unchanged in either case.
 )doc")
       .def_property_readonly(
           "cutoff", [](const VoxelGrid &self) { return self.cutoff(); },

--- a/python/src/nuri/core/geometry.cpp
+++ b/python/src/nuri/core/geometry.cpp
@@ -274,7 +274,7 @@ To update the point set, one must :py:meth:`rebuild()` the octree.
 )doc")
       .def(py::init([](const py::handle &obj, int bucket_size) {
              auto py_arr = py_array_cast<3>(obj);
-             check_interval(bucket_size, "bucket_size", Bounds::kOpenLo, 0);
+             check_positive(bucket_size, "bucket_size");
              OCTreeWrapper self { OCTree(), py_arr.eigen() };
              self.tree.rebuild(self.pts, bucket_size);
              return self;
@@ -293,7 +293,7 @@ Initialize the octree with a set of points.
           "rebuild",
           [](OCTreeWrapper &self, const py::handle &obj, int bucket_size) {
             auto py_arr = py_array_cast<3>(obj);
-            check_interval(bucket_size, "bucket_size", Bounds::kOpenLo, 0);
+            check_positive(bucket_size, "bucket_size");
             self.pts = py_arr.eigen();
             self.tree.rebuild(self.pts, bucket_size);
           },
@@ -317,8 +317,8 @@ Rebuild the octree with a new set of points.
                   "either cutoff distance or number of neighbors must be "
                   "specified");
             }
-            check_interval(xd, "d", Bounds::kOpenLo, 0);
-            check_interval(xk, "k", Bounds::kOpenLo, 0);
+            check_positive(xd, "d");
+            check_positive(xk, "k");
 
             void (*impl)(const OCTree &, const Vector3d &, double, int,
                          std::vector<int> &, std::vector<double> &);
@@ -390,7 +390,7 @@ Find neighbors of each point in the octree.
           "query_tree",
           [](const OCTreeWrapper &self, const OCTreeWrapper &other,
              double d) -> pyt::List<py::array_t<int>> {
-            check_interval(d, "d", Bounds::kOpenLo, 0);
+            check_positive(d, "d");
 
             std::vector<std::vector<int>> idxs =
                 self.tree.find_neighbors_tree(other.tree, d);
@@ -419,7 +419,7 @@ Find all neighbors in another octree.
       .def(
           "query_pairs",
           [](const OCTreeWrapper &self, double d) {
-            check_interval(d, "d", Bounds::kOpenLo, 0);
+            check_positive(d, "d");
 
             std::vector<int> is, js;
             self.tree.find_neighbors_self(d, is, js);
@@ -452,7 +452,7 @@ The voxel grid partitions 3D space into uniform cells, allowing efficient
 distance queries with the cutoff specified at construction time.
 )doc")
       .def(py::init([](const py::handle &obj, double cutoff) {
-             check_interval(cutoff, "cutoff", Bounds::kOpenLo, 0);
+             check_positive(cutoff, "cutoff");
 
              auto py_arr = py_array_cast<3>(obj);
 
@@ -477,7 +477,7 @@ Initialize the voxel grid with a set of points and cutoff distance.
             double cutoff = self.cutoff();
             if (xcutoff) {
               cutoff = *xcutoff;
-              check_interval(cutoff, "cutoff", Bounds::kOpenLo, 0);
+              check_positive(cutoff, "cutoff");
             }
 
             auto py_arr = py_array_cast<3>(obj);

--- a/python/src/nuri/core/geometry.cpp
+++ b/python/src/nuri/core/geometry.cpp
@@ -103,6 +103,15 @@ void find_neighbors_kd(const OCTree &octree, const Vector3d &query, double d,
 }  // namespace
 
 void bind_geometry(py::module &m) {
+  m.doc() = R"doc(
+Geometric utilities for 3D point clouds.
+
+.. note::
+  Every function and method in this module rejects floating-point array inputs
+  containing NaN or infinite values, raising :exc:`ValueError`. This is not
+  repeated in the individual descriptions below.
+)doc";
+
   m.def(
       "align_points",
       [](const py::handle &q_py, const py::handle &t_py,
@@ -152,6 +161,9 @@ Find a 4x4 best-fit rigid-body transformation tensor, to align ``query`` to
   ``False``.
 
 :returns: A tuple of the transformation tensor and the RMSD of the alignment.
+
+:raises ValueError: If the two point sets have different sizes, or if the
+  alignment method is unknown.
 )doc");
 
   m.def(
@@ -196,6 +208,9 @@ Calculate the RMSD of the best-fit rigid-body alignment of ``query`` to
   ``False``.
 
 :returns: The RMSD of the alignment.
+
+:raises ValueError: If the two point sets have different sizes, or if the
+  alignment method is unknown.
 )doc");
 
   m.def(
@@ -262,6 +277,8 @@ Initialize the octree with a set of points.
   numpy array of shape ``(N, 3)``.
 :param bucket_size: The maximum number of points in each leaf node of the
   octree. Defaults to 32.
+
+:raises ValueError: If ``bucket_size`` is not positive.
 )doc")
       .def(
           "rebuild",
@@ -278,6 +295,8 @@ Rebuild the octree with a new set of points.
   numpy array of shape ``(N, 3)``.
 :param bucket_size: The maximum number of points in each leaf node of the
   octree. Defaults to 32.
+
+:raises ValueError: If ``bucket_size`` is not positive.
 )doc")
       .def(
           "find_neighbors",
@@ -354,6 +373,9 @@ Find neighbors of each point in the octree.
   each row is a pair of (query index, neighbor index), and the second array will
   have shape ``(N,)``, where each element is the distance to the corresponding
   neighbor.
+
+:raises ValueError: If neither ``d`` nor ``k`` is specified, or if either is
+  not positive.
 )doc")
       .def(
           "query_tree",
@@ -378,10 +400,12 @@ Find neighbors of each point in the octree.
 Find all neighbors in another octree.
 
 :param other: The other octree to query.
-:param d: The cutoff distance for neighbors. Must be non-negative.
+:param d: The cutoff distance for neighbors. Must be positive.
 :returns: A list of numpy arrays. For point ``i`` in the original octree,
   ``results[i]`` is a 1D numpy array containing the indices of its neighbors in
   the ``other`` octree.
+
+:raises ValueError: If ``d`` is not positive.
 )doc")
       .def(
           "query_pairs",
@@ -403,11 +427,13 @@ Find all neighbors in another octree.
           py::kw_only(), py::arg("d"), R"doc(
 Find all non-redundant pairs of neighbors in the octree.
 
-:param d: The cutoff distance for neighbors. Must be non-negative.
+:param d: The cutoff distance for neighbors. Must be positive.
 :returns: A numpy array of shape ``(N, 2)``, where each row is a pair of
   neighbor indices in the original point set. The pairs are non-redundant,
   meaning that if :math:`(i, j)` is in the array, then :math:`(j, i)` will not
   be in the array, and :math:`i \neq j`.
+
+:raises ValueError: If ``d`` is not positive.
 )doc");
 
   py::class_<VoxelGrid>(m, "VoxelGrid", R"doc(
@@ -428,6 +454,8 @@ Initialize the voxel grid with a set of points and cutoff distance.
 :param pts: The points to build the grid with. Must be representable as a 2D
   numpy array of shape ``(N, 3)``.
 :param cutoff: The cutoff distance for neighbor queries. Must be positive.
+
+:raises ValueError: If ``cutoff`` is not positive.
 )doc")
       .def(
           "rebuild",
@@ -449,6 +477,8 @@ Rebuild the voxel grid with a new set of points.
   numpy array of shape ``(N, 3)``.
 :param cutoff: The cutoff distance for neighbor queries. If omitted, the
   current cutoff is reused. Must be positive when specified.
+
+:raises ValueError: If ``cutoff`` is specified and not positive.
 )doc")
       .def_property_readonly(
           "cutoff", [](const VoxelGrid &self) { return self.cutoff(); },

--- a/python/src/nuri/core/molecule.cpp
+++ b/python/src/nuri/core/molecule.cpp
@@ -491,6 +491,9 @@ void bind_molecule_impl(py::module &m) {
   py::class_<PyMol> mol(m, "Molecule", R"doc(
 A molecule.
 Refer to the ``nuri::Molecule`` class in the |cppdocs| for more details.
+
+Stored coordinates are always finite; NaN and infinite values are rejected with
+:exc:`ValueError`.
 )doc");
   py::class_<PyMutator> mutator(m, "Mutator", R"doc(
 A mutator for a molecule. Use this as a context manager to make changes to a

--- a/python/src/nuri/core/molecule.cpp
+++ b/python/src/nuri/core/molecule.cpp
@@ -400,6 +400,8 @@ int PyMutator::register_bond(int src, int dst, BondData &&data) {
 
 void PyBond::rotate(double angle, bool reverse, bool strict,
                     std::optional<int> conf) {
+  check_finite(angle, "angle");
+
   Molecule::Bond bond = **this;
   if (strict && !bond.data().is_rotatable())
     throw py::value_error("bond is not rotatable");

--- a/python/src/nuri/core/substructure.cpp
+++ b/python/src/nuri/core/substructure.cpp
@@ -1158,12 +1158,11 @@ A collection of substructures of a molecule.
           [](ProxySubstructContainer &self, const std::optional<int> &oi) {
             Molecule &mol = *self.mol();
 
-            int idx;
-            if (oi) {
-              idx = check_sub(mol, *oi);
-            } else {
-              idx = static_cast<int>(mol.substructures().size() - 1);
-            }
+            if (mol.substructures().empty())
+              throw py::index_error("pop from empty substructure container");
+
+            int idx = oi ? check_sub(mol, *oi)
+                         : static_cast<int>(mol.substructures().size() - 1);
 
             PySubstruct ret = PySubstruct::from_mol(
                 self.mol(), std::move(mol.substructures()[idx]));

--- a/python/src/nuri/desc/desc_module.cpp
+++ b/python/src/nuri/desc/desc_module.cpp
@@ -16,8 +16,8 @@ namespace nuri {
 namespace python_internal {
 namespace {
 void sr_sasa_validate_common_args(int nprobe, double rprobe) {
-  check_positive(nprobe, "number of probes");
-  check_positive(rprobe, "radius of probes");
+  check_interval(nprobe, "number of probes", Bounds::kLeftOpen, 0);
+  check_interval(rprobe, "radius of probes", Bounds::kLeftOpen, 0);
 }
 
 NURI_PYTHON_MODULE(m) {

--- a/python/src/nuri/desc/desc_module.cpp
+++ b/python/src/nuri/desc/desc_module.cpp
@@ -16,15 +16,8 @@ namespace nuri {
 namespace python_internal {
 namespace {
 void sr_sasa_validate_common_args(int nprobe, double rprobe) {
-  if (nprobe <= 0) {
-    throw py::value_error(
-        absl::StrCat("number of probes must be positive, got ", nprobe));
-  }
-
-  if (!(rprobe > 0)) {
-    throw py::value_error(
-        absl::StrCat("radius of probes must be positive, got ", rprobe));
-  }
+  check_positive(nprobe, "number of probes");
+  check_positive(rprobe, "radius of probes");
 }
 
 NURI_PYTHON_MODULE(m) {

--- a/python/src/nuri/desc/desc_module.cpp
+++ b/python/src/nuri/desc/desc_module.cpp
@@ -16,8 +16,8 @@ namespace nuri {
 namespace python_internal {
 namespace {
 void sr_sasa_validate_common_args(int nprobe, double rprobe) {
-  check_interval(nprobe, "number of probes", Bounds::kLeftOpen, 0);
-  check_interval(rprobe, "radius of probes", Bounds::kLeftOpen, 0);
+  check_interval(nprobe, "nprobe", Bounds::kLeftOpen, 0);
+  check_interval(rprobe, "rprobe", Bounds::kLeftOpen, 0);
 }
 
 NURI_PYTHON_MODULE(m) {

--- a/python/src/nuri/desc/desc_module.cpp
+++ b/python/src/nuri/desc/desc_module.cpp
@@ -16,8 +16,8 @@ namespace nuri {
 namespace python_internal {
 namespace {
 void sr_sasa_validate_common_args(int nprobe, double rprobe) {
-  check_interval(nprobe, "nprobe", Bounds::kLeftOpen, 0);
-  check_interval(rprobe, "rprobe", Bounds::kLeftOpen, 0);
+  check_interval(nprobe, "nprobe", Bounds::kOpenLo, 0);
+  check_interval(rprobe, "rprobe", Bounds::kOpenLo, 0);
 }
 
 NURI_PYTHON_MODULE(m) {

--- a/python/src/nuri/desc/desc_module.cpp
+++ b/python/src/nuri/desc/desc_module.cpp
@@ -16,8 +16,8 @@ namespace nuri {
 namespace python_internal {
 namespace {
 void sr_sasa_validate_common_args(int nprobe, double rprobe) {
-  check_interval(nprobe, "nprobe", Bounds::kOpenLo, 0);
-  check_interval(rprobe, "rprobe", Bounds::kOpenLo, 0);
+  check_positive(nprobe, "nprobe");
+  check_positive(rprobe, "rprobe");
 }
 
 NURI_PYTHON_MODULE(m) {

--- a/python/src/nuri/fmt/cif.cpp
+++ b/python/src/nuri/fmt/cif.cpp
@@ -521,7 +521,7 @@ overloaded on the type of ``value``.
       .def(py::init([](int width, std::optional<int> precision, bool raw,
                        bool short_form, std::string_view null_token,
                        bool coerce_nonfinite) {
-             check_positive(precision, "precision", Bounds::kClosed);
+             check_interval(precision, "precision", Bounds::kClosed, 0);
              return ColumnFormat {
                width,      precision.value_or(-1),       raw,
                short_form, parse_null_token(null_token), coerce_nonfinite
@@ -716,7 +716,7 @@ Store an integer CIF value.
 )doc");
   cv.def(py::init([](double value, std::optional<int> prec,
                      bool coerce_nonfinite, std::string_view null_token) {
-           check_positive(prec, "precision", Bounds::kClosed);
+           check_interval(prec, "precision", Bounds::kClosed, 0);
 
            return cif_value(value, prec.value_or(-1), coerce_nonfinite,
                             parse_null_token(null_token));

--- a/python/src/nuri/fmt/cif.cpp
+++ b/python/src/nuri/fmt/cif.cpp
@@ -40,6 +40,10 @@ namespace python_internal {
 namespace {
 namespace fs = std::filesystem;
 
+// A 64-bit integer never needs more than 20 digits, and a CIF line is
+// conventionally at most 80 characters wide
+constexpr int kMaxWidth = 80;
+
 class PyCifTable;
 
 // Per-column formatting options, mirroring the CifValue constructor keywords.
@@ -521,6 +525,7 @@ overloaded on the type of ``value``.
       .def(py::init([](int width, std::optional<int> precision, bool raw,
                        bool short_form, std::string_view null_token,
                        bool coerce_nonfinite) {
+             check_interval(width, "width", Bounds::kClosed, 0, kMaxWidth);
              check_interval(precision, "precision", Bounds::kClosed, 0);
              return ColumnFormat {
                width,      precision.value_or(-1),       raw,
@@ -539,7 +544,7 @@ applies only to cells of its matching type; the others are ignored. Explicit
 :class:`Value` cells are never affected.
 
 :param width: For :class:`int` cells, zero-pad the number to at least this many
-  digits.
+  digits. Must be between 0 and 80.
 :param precision: For :class:`float` cells, digits after the decimal point; if
   ``None`` (the default), yields at most 6 significant digits. Must be
   non-negative if provided.
@@ -707,12 +712,16 @@ Store a boolean CIF value.
 :param value: The boolean to store.
 :param short_form: Use ``y``/``n`` instead of ``yes``/``no``.
 )doc");
-  cv.def(py::init(&cif_value<std::int64_t>), py::arg("value"),
-         py::arg("width") = 0, R"doc(
+  cv.def(py::init([](std::int64_t value, int width) {
+           check_interval(width, "width", Bounds::kClosed, 0, kMaxWidth);
+           return cif_value(value, width);
+         }),
+         py::arg("value"), py::arg("width") = 0, R"doc(
 Store an integer CIF value.
 
 :param value: The integer to store.
 :param width: If positive, zero-pad the number to at least this many digits.
+  Must be at most 80.
 )doc");
   cv.def(py::init([](double value, std::optional<int> prec,
                      bool coerce_nonfinite, std::string_view null_token) {

--- a/python/src/nuri/fmt/cif.cpp
+++ b/python/src/nuri/fmt/cif.cpp
@@ -525,8 +525,8 @@ overloaded on the type of ``value``.
       .def(py::init([](std::optional<int> width, std::optional<int> precision,
                        bool raw, bool short_form, std::string_view null_token,
                        bool coerce_nonfinite) {
-             check_interval(width, "width", Bounds::kOpenLo, 1, kMaxWidth);
-             check_interval(precision, "precision", Bounds::kClosed, 0);
+             check_interval(width, "width", Bounds::kLeftOpen, 1, kMaxWidth);
+             check_nonneg(precision, "precision");
              return ColumnFormat {
                width.value_or(0), precision.value_or(-1),       raw,
                short_form,        parse_null_token(null_token), coerce_nonfinite
@@ -722,7 +722,7 @@ Store a boolean CIF value.
 :param short_form: Use ``y``/``n`` instead of ``yes``/``no``.
 )doc");
   cv.def(py::init([](std::int64_t value, std::optional<int> width) {
-           check_interval(width, "width", Bounds::kOpenLo, 1, kMaxWidth);
+           check_interval(width, "width", Bounds::kLeftOpen, 1, kMaxWidth);
            return cif_value(value, width.value_or(0));
          }),
          py::arg("value"), py::arg("width") = py::none(), R"doc(
@@ -735,7 +735,7 @@ Store an integer CIF value.
 )doc");
   cv.def(py::init([](double value, std::optional<int> prec,
                      bool coerce_nonfinite, std::string_view null_token) {
-           check_interval(prec, "precision", Bounds::kClosed, 0);
+           check_nonneg(prec, "precision");
 
            return cif_value(value, prec.value_or(-1), coerce_nonfinite,
                             parse_null_token(null_token));

--- a/python/src/nuri/fmt/cif.cpp
+++ b/python/src/nuri/fmt/cif.cpp
@@ -525,7 +525,7 @@ overloaded on the type of ``value``.
       .def(py::init([](std::optional<int> width, std::optional<int> precision,
                        bool raw, bool short_form, std::string_view null_token,
                        bool coerce_nonfinite) {
-             check_interval(width, "width", Bounds::kLeftOpen, 1, kMaxWidth);
+             check_interval(width, "width", Bounds::kClosed, 1, kMaxWidth);
              check_nonneg(precision, "precision");
              return ColumnFormat {
                width.value_or(0), precision.value_or(-1),       raw,
@@ -545,7 +545,7 @@ applies only to cells of its matching type; the others are ignored. Explicit
 
 :param width: For :class:`int` cells, zero-pad the number to at least this many
   digits. If ``None`` (the default), the number is not padded. Must be between
-  2 and 80 if provided.
+  1 and 80 if provided.
 :param precision: For :class:`float` cells, digits after the decimal point; if
   ``None`` (the default), yields at most 6 significant digits. Must be
   non-negative if provided.
@@ -722,7 +722,7 @@ Store a boolean CIF value.
 :param short_form: Use ``y``/``n`` instead of ``yes``/``no``.
 )doc");
   cv.def(py::init([](std::int64_t value, std::optional<int> width) {
-           check_interval(width, "width", Bounds::kLeftOpen, 1, kMaxWidth);
+           check_interval(width, "width", Bounds::kClosed, 1, kMaxWidth);
            return cif_value(value, width.value_or(0));
          }),
          py::arg("value"), py::arg("width") = py::none(), R"doc(
@@ -730,7 +730,7 @@ Store an integer CIF value.
 
 :param value: The integer to store.
 :param width: Zero-pad the number to at least this many digits. If ``None``
-  (the default), the number is not padded. Must be between 2 and 80 if
+  (the default), the number is not padded. Must be between 1 and 80 if
   provided.
 )doc");
   cv.def(py::init([](double value, std::optional<int> prec,

--- a/python/src/nuri/fmt/cif.cpp
+++ b/python/src/nuri/fmt/cif.cpp
@@ -522,17 +522,17 @@ overloaded on the type of ``value``.
 )doc");
 
   py::class_<ColumnFormat>(m, "ColumnFormat")
-      .def(py::init([](int width, std::optional<int> precision, bool raw,
-                       bool short_form, std::string_view null_token,
+      .def(py::init([](std::optional<int> width, std::optional<int> precision,
+                       bool raw, bool short_form, std::string_view null_token,
                        bool coerce_nonfinite) {
-             check_interval(width, "width", Bounds::kClosed, 0, kMaxWidth);
+             check_interval(width, "width", Bounds::kOpenLo, 1, kMaxWidth);
              check_interval(precision, "precision", Bounds::kClosed, 0);
              return ColumnFormat {
-               width,      precision.value_or(-1),       raw,
-               short_form, parse_null_token(null_token), coerce_nonfinite
+               width.value_or(0), precision.value_or(-1),       raw,
+               short_form,        parse_null_token(null_token), coerce_nonfinite
              };
            }),
-           py::kw_only(), py::arg("width") = 0,
+           py::kw_only(), py::arg("width") = py::none(),
            py::arg("precision") = py::none(), py::arg("raw") = false,
            py::arg("short_form") = false, py::arg("null_token") = "?",
            py::arg("coerce_nonfinite") = false, R"doc(
@@ -544,7 +544,8 @@ applies only to cells of its matching type; the others are ignored. Explicit
 :class:`Value` cells are never affected.
 
 :param width: For :class:`int` cells, zero-pad the number to at least this many
-  digits. Must be between 0 and 80.
+  digits. If ``None`` (the default), the number is not padded. Must be between
+  2 and 80 if provided.
 :param precision: For :class:`float` cells, digits after the decimal point; if
   ``None`` (the default), yields at most 6 significant digits. Must be
   non-negative if provided.
@@ -558,10 +559,16 @@ applies only to cells of its matching type; the others are ignored. Explicit
 :param coerce_nonfinite: For :class:`float` cells, coerce a non-finite value to
   a safe representation (``NaN`` to the ``null_token``, ``+/-Inf`` to a
   sentinel) instead of raising when serialized.
-:raises ValueError: If ``precision`` is negative or ``null_token`` is not
-  ``"?"`` or ``"."``.
+:raises ValueError: If ``width`` or ``precision`` is out of range, or
+  ``null_token`` is not ``"?"`` or ``"."``.
 )doc")
-      .def_readonly("width", &ColumnFormat::width)
+      .def_property_readonly(
+          "width",
+          [](const ColumnFormat &f) -> pyt::Optional<py::int_> {
+            if (f.width <= 0)
+              return py::none();
+            return py::int_(f.width);
+          })
       .def_property_readonly(
           "precision",
           [](const ColumnFormat &f) -> pyt::Optional<py::int_> {
@@ -579,7 +586,9 @@ applies only to cells of its matching type; the others are ignored. Explicit
       .def("__repr__", [](const ColumnFormat &f) {
         auto pybool = [](bool v) { return v ? "True" : "False"; };
         return absl::StrCat(
-            "ColumnFormat(width=", f.width, ", precision=",
+            "ColumnFormat(width=",
+            f.width <= 0 ? std::string("None") : absl::StrCat(f.width),
+            ", precision=",
             f.precision < 0 ? std::string("None") : absl::StrCat(f.precision),
             ", raw=", pybool(f.raw), ", short_form=", pybool(f.short_form),
             ", null_token='", f.null_unknown ? "?" : ".",
@@ -712,16 +721,17 @@ Store a boolean CIF value.
 :param value: The boolean to store.
 :param short_form: Use ``y``/``n`` instead of ``yes``/``no``.
 )doc");
-  cv.def(py::init([](std::int64_t value, int width) {
-           check_interval(width, "width", Bounds::kClosed, 0, kMaxWidth);
-           return cif_value(value, width);
+  cv.def(py::init([](std::int64_t value, std::optional<int> width) {
+           check_interval(width, "width", Bounds::kOpenLo, 1, kMaxWidth);
+           return cif_value(value, width.value_or(0));
          }),
-         py::arg("value"), py::arg("width") = 0, R"doc(
+         py::arg("value"), py::arg("width") = py::none(), R"doc(
 Store an integer CIF value.
 
 :param value: The integer to store.
-:param width: If positive, zero-pad the number to at least this many digits.
-  Must be at most 80.
+:param width: Zero-pad the number to at least this many digits. If ``None``
+  (the default), the number is not padded. Must be between 2 and 80 if
+  provided.
 )doc");
   cv.def(py::init([](double value, std::optional<int> prec,
                      bool coerce_nonfinite, std::string_view null_token) {

--- a/python/src/nuri/fmt/cif.cpp
+++ b/python/src/nuri/fmt/cif.cpp
@@ -521,8 +521,7 @@ overloaded on the type of ``value``.
       .def(py::init([](int width, std::optional<int> precision, bool raw,
                        bool short_form, std::string_view null_token,
                        bool coerce_nonfinite) {
-             if (precision.has_value() && *precision < 0)
-               throw py::value_error("precision must be non-negative");
+             check_positive(precision, "precision", Bounds::kClosed);
              return ColumnFormat {
                width,      precision.value_or(-1),       raw,
                short_form, parse_null_token(null_token), coerce_nonfinite
@@ -717,8 +716,7 @@ Store an integer CIF value.
 )doc");
   cv.def(py::init([](double value, std::optional<int> prec,
                      bool coerce_nonfinite, std::string_view null_token) {
-           if (prec.has_value() && prec.value() < 0)
-             throw py::value_error("precision must be non-negative");
+           check_positive(prec, "precision", Bounds::kClosed);
 
            return cif_value(value, prec.value_or(-1), coerce_nonfinite,
                             parse_null_token(null_token));

--- a/python/src/nuri/fmt/fmt_module.cpp
+++ b/python/src/nuri/fmt/fmt_module.cpp
@@ -177,8 +177,12 @@ Read a molecule from a file.
 :param skip_on_error: Whether to skip a molecule if an error occurs, instead of
   raising an exception.
 :raises OSError: If any file-related error occurs.
-:raises ValueError: If the format is unknown or sanitization fails, unless
-  `skip_on_error` is set.
+:raises ValueError: If the format is unknown, or if a molecule cannot be read
+  or sanitized, unless `skip_on_error` is set.
+
+.. note::
+  The yielded molecules always have finite coordinates; NaN or infinite
+  coordinates are considered an error.
 )doc")
       .def(
           "readstring",
@@ -201,14 +205,18 @@ Read a molecule from string.
   (:func:`nuri.algo.guess_everything()`).
 :param skip_on_error: Whether to skip a molecule if an error occurs, instead of
   raising an exception.
-:raises ValueError: If the format is unknown or sanitization fails, unless
-  `skip_on_error` is set.
+:raises ValueError: If the format is unknown, or if a molecule cannot be read
+  or sanitized, unless `skip_on_error` is set.
 
-The returned object is an iterable of molecules.
+The returned object is an iterator of molecules.
 
 >>> for mol in nuri.readstring("smi", "C"):
 ...     print(mol[0].atomic_number)
 6
+
+.. note::
+  The yielded molecules always have finite coordinates; NaN or infinite
+  coordinates are considered an error.
 )doc");
 
   m.def(

--- a/python/src/nuri/fmt/fmt_module.cpp
+++ b/python/src/nuri/fmt/fmt_module.cpp
@@ -14,6 +14,7 @@
 #include <utility>
 #include <vector>
 
+#include <absl/algorithm/container.h>
 #include <absl/log/absl_log.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_join.h>
@@ -22,6 +23,7 @@
 #include <pybind11/pytypes.h>
 #include <pybind11/stl/filesystem.h>
 
+#include "nuri/eigen_config.h"
 #include "fmt_internal.h"
 #include "nuri/algo/guess.h"
 #include "nuri/core/molecule.h"
@@ -37,6 +39,11 @@
 namespace nuri {
 namespace python_internal {
 namespace {
+bool all_confs_finite(const Molecule &mol) {
+  return absl::c_all_of(mol.confs(),
+                        [](const Matrix3Xd &conf) { return conf.allFinite(); });
+}
+
 class PyMoleculeReader {
 public:
   PyMoleculeReader(std::unique_ptr<std::istream> is, std::string_view fmt,
@@ -76,6 +83,11 @@ public:
                                         "\n  "));
         }
         log_or_throw(text.c_str());
+        continue;
+      }
+
+      if (!all_confs_finite(mol)) {
+        log_or_throw("Molecule has non-finite (NaN or infinite) coordinates.");
         continue;
       }
 

--- a/python/src/nuri/tools/chimera_module.cpp
+++ b/python/src/nuri/tools/chimera_module.cpp
@@ -59,9 +59,10 @@ The root-mean-square deviation of the selected (inlier) points after alignment.
                            "number of points, got ",
                            query.eigen().cols(), " vs ", templ.eigen().cols()));
         }
-        check_interval(cutoff, "cutoff", Bounds::kOpenLo, 0);
-        check_interval(global_ratio, "global_ratio", Bounds::kOpenLo, 0.0, 1.0);
-        check_interval(viol_ratio, "viol_ratio", Bounds::kOpenLo, 0.0, 1.0);
+        check_positive(cutoff, "cutoff");
+        check_interval(global_ratio, "global_ratio", Bounds::kLeftOpen, 0.0,
+                       1.0);
+        check_interval(viol_ratio, "viol_ratio", Bounds::kLeftOpen, 0.0, 1.0);
 
         auto ret = match_maker(query.eigen(), templ.eigen(), cutoff,
                                global_ratio, viol_ratio);

--- a/python/src/nuri/tools/chimera_module.cpp
+++ b/python/src/nuri/tools/chimera_module.cpp
@@ -59,10 +59,10 @@ The root-mean-square deviation of the selected (inlier) points after alignment.
                            "number of points, got ",
                            query.eigen().cols(), " vs ", templ.eigen().cols()));
         }
-        check_positive(cutoff, "cutoff");
-        check_interval(global_ratio, 0.0, 1.0, "global_ratio",
-                       Bounds::kLeftOpen);
-        check_interval(viol_ratio, 0.0, 1.0, "viol_ratio", Bounds::kLeftOpen);
+        check_interval(cutoff, "cutoff", Bounds::kLeftOpen, 0);
+        check_interval(global_ratio, "global_ratio", Bounds::kLeftOpen, 0.0,
+                       1.0);
+        check_interval(viol_ratio, "viol_ratio", Bounds::kLeftOpen, 0.0, 1.0);
 
         auto ret = match_maker(query.eigen(), templ.eigen(), cutoff,
                                global_ratio, viol_ratio);

--- a/python/src/nuri/tools/chimera_module.cpp
+++ b/python/src/nuri/tools/chimera_module.cpp
@@ -59,10 +59,9 @@ The root-mean-square deviation of the selected (inlier) points after alignment.
                            "number of points, got ",
                            query.eigen().cols(), " vs ", templ.eigen().cols()));
         }
-        check_interval(cutoff, "cutoff", Bounds::kLeftOpen, 0);
-        check_interval(global_ratio, "global_ratio", Bounds::kLeftOpen, 0.0,
-                       1.0);
-        check_interval(viol_ratio, "viol_ratio", Bounds::kLeftOpen, 0.0, 1.0);
+        check_interval(cutoff, "cutoff", Bounds::kOpenLo, 0);
+        check_interval(global_ratio, "global_ratio", Bounds::kOpenLo, 0.0, 1.0);
+        check_interval(viol_ratio, "viol_ratio", Bounds::kOpenLo, 0.0, 1.0);
 
         auto ret = match_maker(query.eigen(), templ.eigen(), cutoff,
                                global_ratio, viol_ratio);

--- a/python/src/nuri/tools/chimera_module.cpp
+++ b/python/src/nuri/tools/chimera_module.cpp
@@ -59,19 +59,10 @@ The root-mean-square deviation of the selected (inlier) points after alignment.
                            "number of points, got ",
                            query.eigen().cols(), " vs ", templ.eigen().cols()));
         }
-
-        if (cutoff <= 0.0) {
-          throw py::value_error(
-              absl::StrCat("distance cutoff must be positive, got ", cutoff));
-        }
-        if (global_ratio <= 0.0 || global_ratio > 1.0) {
-          throw py::value_error(absl::StrCat(
-              "global_ratio must be between 0 and 1, got ", global_ratio));
-        }
-        if (viol_ratio <= 0.0 || viol_ratio > 1.0) {
-          throw py::value_error(absl::StrCat(
-              "viol_ratio must be between 0 and 1, got ", viol_ratio));
-        }
+        check_positive(cutoff, "cutoff");
+        check_interval(global_ratio, 0.0, 1.0, "global_ratio",
+                       Bounds::kLeftOpen);
+        check_interval(viol_ratio, 0.0, 1.0, "viol_ratio", Bounds::kLeftOpen);
 
         auto ret = match_maker(query.eigen(), templ.eigen(), cutoff,
                                global_ratio, viol_ratio);

--- a/python/src/nuri/tools/galign_module.cpp
+++ b/python/src/nuri/tools/galign_module.cpp
@@ -47,9 +47,9 @@ GARigidMolInfo galign_init(const PyMol &mol, std::optional<int> conf,
 
   const Matrix3Xd &ref = galign_try_get_conf(mol, conf);
 
-  check_positive(vdw_scale, "vdw_scale");
-  check_positive(hetero_scale, "hetero_scale");
-  check_positive(dcut, "dcut");
+  check_interval(vdw_scale, "vdw_scale", Bounds::kLeftOpen, 0);
+  check_interval(hetero_scale, "hetero_scale", Bounds::kLeftOpen, 0);
+  check_interval(dcut, "dcut", Bounds::kLeftOpen, 0);
 
   GARigidMolInfo galign(*mol, ref, vdw_scale, hetero_scale, dcut);
   return galign;
@@ -64,20 +64,20 @@ galign_align(const GARigidMolInfo &self, const PyMol &query, bool flexible,
              int max_iters) {
   const Matrix3Xd &seed = galign_try_get_conf(query, conf);
 
-  check_positive(max_conf, "max_confs");
-  check_positive(max_trs, "max_translation", Bounds::kClosed);
-  check_positive(max_rot, "max_rotation", Bounds::kClosed);
-  check_positive(max_tors, "max_torsion", Bounds::kClosed);
-  check_positive(rigid_min_rmsd, "rigid_min_rmsd", Bounds::kClosed);
-  check_positive(rigid_max_conf, "rigid_max_confs");
-  check_positive(pool_size, "pool_size");
-  check_positive(sample_size, "sample_size");
-  check_positive(max_gen, "max_generations");
-  check_positive(patience, "patience");
-  check_positive(mut_cnt, "n_mutation", Bounds::kClosed);
-  check_interval(mut_prob, 0.0, 1.0, "p_mutation");
-  check_positive(ftol, "opt_ftol");
-  check_positive(max_iters, "opt_max_iters");
+  check_interval(max_conf, "max_confs", Bounds::kLeftOpen, 0);
+  check_interval(max_trs, "max_translation", Bounds::kClosed, 0);
+  check_interval(max_rot, "max_rotation", Bounds::kClosed, 0);
+  check_interval(max_tors, "max_torsion", Bounds::kClosed, 0);
+  check_interval(rigid_min_rmsd, "rigid_min_rmsd", Bounds::kClosed, 0);
+  check_interval(rigid_max_conf, "rigid_max_confs", Bounds::kLeftOpen, 0);
+  check_interval(pool_size, "pool_size", Bounds::kLeftOpen, 0);
+  check_interval(sample_size, "sample_size", Bounds::kLeftOpen, 0);
+  check_interval(max_gen, "max_generations", Bounds::kLeftOpen, 0);
+  check_interval(patience, "patience", Bounds::kLeftOpen, 0);
+  check_interval(mut_cnt, "n_mutation", Bounds::kClosed, 0);
+  check_interval(mut_prob, "p_mutation", Bounds::kClosed, 0.0, 1.0);
+  check_interval(ftol, "opt_ftol", Bounds::kLeftOpen, 0);
+  check_interval(max_iters, "opt_max_iters", Bounds::kLeftOpen, 0);
 
   GAMinimizeArgs margs;
   if (flexible) {

--- a/python/src/nuri/tools/galign_module.cpp
+++ b/python/src/nuri/tools/galign_module.cpp
@@ -47,9 +47,9 @@ GARigidMolInfo galign_init(const PyMol &mol, std::optional<int> conf,
 
   const Matrix3Xd &ref = galign_try_get_conf(mol, conf);
 
-  check_interval(vdw_scale, "vdw_scale", Bounds::kLeftOpen, 0);
-  check_interval(hetero_scale, "hetero_scale", Bounds::kLeftOpen, 0);
-  check_interval(dcut, "dcut", Bounds::kLeftOpen, 0);
+  check_interval(vdw_scale, "vdw_scale", Bounds::kOpenLo, 0);
+  check_interval(hetero_scale, "hetero_scale", Bounds::kOpenLo, 0);
+  check_interval(dcut, "dcut", Bounds::kOpenLo, 0);
 
   GARigidMolInfo galign(*mol, ref, vdw_scale, hetero_scale, dcut);
   return galign;
@@ -64,20 +64,20 @@ galign_align(const GARigidMolInfo &self, const PyMol &query, bool flexible,
              int max_iters) {
   const Matrix3Xd &seed = galign_try_get_conf(query, conf);
 
-  check_interval(max_conf, "max_confs", Bounds::kLeftOpen, 0);
+  check_interval(max_conf, "max_confs", Bounds::kOpenLo, 0);
   check_interval(max_trs, "max_translation", Bounds::kClosed, 0);
   check_interval(max_rot, "max_rotation", Bounds::kClosed, 0);
   check_interval(max_tors, "max_torsion", Bounds::kClosed, 0);
   check_interval(rigid_min_rmsd, "rigid_min_rmsd", Bounds::kClosed, 0);
-  check_interval(rigid_max_conf, "rigid_max_confs", Bounds::kLeftOpen, 0);
-  check_interval(pool_size, "pool_size", Bounds::kLeftOpen, 0);
-  check_interval(sample_size, "sample_size", Bounds::kLeftOpen, 0);
-  check_interval(max_gen, "max_generations", Bounds::kLeftOpen, 0);
-  check_interval(patience, "patience", Bounds::kLeftOpen, 0);
+  check_interval(rigid_max_conf, "rigid_max_confs", Bounds::kOpenLo, 0);
+  check_interval(pool_size, "pool_size", Bounds::kOpenLo, 0);
+  check_interval(sample_size, "sample_size", Bounds::kOpenLo, 0);
+  check_interval(max_gen, "max_generations", Bounds::kOpenLo, 0);
+  check_interval(patience, "patience", Bounds::kOpenLo, 0);
   check_interval(mut_cnt, "n_mutation", Bounds::kClosed, 0);
   check_interval(mut_prob, "p_mutation", Bounds::kClosed, 0.0, 1.0);
-  check_interval(ftol, "opt_ftol", Bounds::kLeftOpen, 0);
-  check_interval(max_iters, "opt_max_iters", Bounds::kLeftOpen, 0);
+  check_interval(ftol, "opt_ftol", Bounds::kOpenLo, 0);
+  check_interval(max_iters, "opt_max_iters", Bounds::kOpenLo, 0);
 
   GAMinimizeArgs margs;
   if (flexible) {

--- a/python/src/nuri/tools/galign_module.cpp
+++ b/python/src/nuri/tools/galign_module.cpp
@@ -69,7 +69,7 @@ galign_align(const GARigidMolInfo &self, const PyMol &query, bool flexible,
   check_positive(max_trs, "max_translation", Bounds::kClosed);
   check_positive(max_rot, "max_rotation", Bounds::kClosed);
   check_positive(max_tors, "max_torsion", Bounds::kClosed);
-  check_positive(rigid_min_rmsd, "rigid_min_msd", Bounds::kClosed);
+  check_positive(rigid_min_rmsd, "rigid_min_rmsd", Bounds::kClosed);
   check_positive(rigid_max_conf, "rigid_max_confs");
   check_positive(pool_size, "pool_size");
   check_positive(sample_size, "sample_size");
@@ -145,7 +145,7 @@ Prepare GAlign algorithm with the given template structure.
            py::arg("conf") = py::none(), py::arg("max_translation") = 2.5,
            py::arg("max_rotation") = deg2rad(120),
            py::arg("max_torsion") = deg2rad(120),
-           py::arg("rigid_min_msd") = 9.0, py::arg("rigid_max_confs") = 4,
+           py::arg("rigid_min_rmsd") = 3.0, py::arg("rigid_max_confs") = 4,
            py::arg("pool_size") = 10, py::arg("sample_size") = 30,
            py::arg("max_generations") = 50, py::arg("patience") = 5,
            py::arg("n_mutation") = 5, py::arg("p_mutation") = 0.5,
@@ -222,7 +222,7 @@ Align the given query molecule to the template structure.
       py::arg("vdw_scale") = 0.8, py::arg("hetero_scale") = 0.7,
       py::arg("dcut") = 6, py::arg("max_translation") = 2.5,
       py::arg("max_rotation") = deg2rad(120),
-      py::arg("max_torsion") = deg2rad(120), py::arg("rigid_min_msd") = 9.0,
+      py::arg("max_torsion") = deg2rad(120), py::arg("rigid_min_rmsd") = 3.0,
       py::arg("rigid_max_confs") = 4, py::arg("pool_size") = 10,
       py::arg("sample_size") = 30, py::arg("max_generations") = 50,
       py::arg("patience") = 5, py::arg("n_mutation") = 5,

--- a/python/src/nuri/tools/galign_module.cpp
+++ b/python/src/nuri/tools/galign_module.cpp
@@ -64,7 +64,6 @@ galign_align(const GARigidMolInfo &self, const PyMol &query, bool flexible,
              int max_iters) {
   const Matrix3Xd &seed = galign_try_get_conf(query, conf);
 
-  // Every scalar below reaches GASamplingArgs regardless of `flexible`.
   check_positive(max_conf, "max_confs");
   check_positive(max_trs, "max_translation", Bounds::kClosed);
   check_positive(max_rot, "max_rotation", Bounds::kClosed);

--- a/python/src/nuri/tools/galign_module.cpp
+++ b/python/src/nuri/tools/galign_module.cpp
@@ -47,18 +47,9 @@ GARigidMolInfo galign_init(const PyMol &mol, std::optional<int> conf,
 
   const Matrix3Xd &ref = galign_try_get_conf(mol, conf);
 
-  if (vdw_scale <= 0.0) {
-    throw py::value_error(
-        absl::StrCat("vdw_scale must be positive, got ", vdw_scale));
-  }
-  if (hetero_scale <= 0.0) {
-    throw py::value_error(
-        absl::StrCat("hetero_scale must be positive, got ", hetero_scale));
-  }
-  if (dcut < 1) {
-    throw py::value_error(
-        absl::StrCat("dcut must be at least 1 angstrom, got ", dcut));
-  }
+  check_positive(vdw_scale, "vdw_scale");
+  check_positive(hetero_scale, "hetero_scale");
+  check_positive(dcut, "dcut");
 
   GARigidMolInfo galign(*mol, ref, vdw_scale, hetero_scale, dcut);
   return galign;
@@ -73,54 +64,24 @@ galign_align(const GARigidMolInfo &self, const PyMol &query, bool flexible,
              int max_iters) {
   const Matrix3Xd &seed = galign_try_get_conf(query, conf);
 
-  if (max_conf < 1) {
-    throw py::value_error(
-        absl::StrCat("max_confs must be at least 1, got ", max_conf));
-  }
+  // Every scalar below reaches GASamplingArgs regardless of `flexible`.
+  check_positive(max_conf, "max_confs");
+  check_positive(max_trs, "max_translation", Bounds::kClosed);
+  check_positive(max_rot, "max_rotation", Bounds::kClosed);
+  check_positive(max_tors, "max_torsion", Bounds::kClosed);
+  check_positive(rigid_min_rmsd, "rigid_min_msd", Bounds::kClosed);
+  check_positive(rigid_max_conf, "rigid_max_confs");
+  check_positive(pool_size, "pool_size");
+  check_positive(sample_size, "sample_size");
+  check_positive(max_gen, "max_generations");
+  check_positive(patience, "patience");
+  check_positive(mut_cnt, "n_mutation", Bounds::kClosed);
+  check_interval(mut_prob, 0.0, 1.0, "p_mutation");
+  check_positive(ftol, "opt_ftol");
+  check_positive(max_iters, "opt_max_iters");
 
   GAMinimizeArgs margs;
   if (flexible) {
-    if (max_trs < 0.0) {
-      throw py::value_error(
-          absl::StrCat("max_translation must be nonnegative, got ", max_trs));
-    }
-    if (max_rot < 0.0) {
-      throw py::value_error(
-          absl::StrCat("max_rotation must be nonnegative, got ", max_rot));
-    }
-    if (max_tors < 0.0) {
-      throw py::value_error(
-          absl::StrCat("max_torsion must be nonnegative, got ", max_tors));
-    }
-    if (pool_size < 1) {
-      throw py::value_error(
-          absl::StrCat("pool_size must be at least 1, got ", pool_size));
-    }
-    if (sample_size < 1) {
-      throw py::value_error(
-          absl::StrCat("sample_size must be at least 1, got ", sample_size));
-    }
-    if (max_gen < 1) {
-      throw py::value_error(
-          absl::StrCat("max_generations must be at least 1, got ", max_gen));
-    }
-    if (mut_cnt < 0) {
-      throw py::value_error(
-          absl::StrCat("n_mutation must be nonnegative, got ", mut_cnt));
-    }
-    if (mut_prob < 0.0 || mut_prob > 1.0) {
-      throw py::value_error(
-          absl::StrCat("p_mutation must be between 0 and 1, got ", mut_prob));
-    }
-    if (ftol <= 0.0) {
-      throw py::value_error(
-          absl::StrCat("opt_ftol must be positive, got ", ftol));
-    }
-    if (max_iters < 1) {
-      throw py::value_error(
-          absl::StrCat("opt_max_iters must be at least 1, got ", max_iters));
-    }
-
     margs.ftol = ftol;
     margs.max_iters = max_iters;
   }

--- a/python/src/nuri/tools/galign_module.cpp
+++ b/python/src/nuri/tools/galign_module.cpp
@@ -47,9 +47,9 @@ GARigidMolInfo galign_init(const PyMol &mol, std::optional<int> conf,
 
   const Matrix3Xd &ref = galign_try_get_conf(mol, conf);
 
-  check_interval(vdw_scale, "vdw_scale", Bounds::kOpenLo, 0);
-  check_interval(hetero_scale, "hetero_scale", Bounds::kOpenLo, 0);
-  check_interval(dcut, "dcut", Bounds::kOpenLo, 0);
+  check_positive(vdw_scale, "vdw_scale");
+  check_positive(hetero_scale, "hetero_scale");
+  check_positive(dcut, "dcut");
 
   GARigidMolInfo galign(*mol, ref, vdw_scale, hetero_scale, dcut);
   return galign;
@@ -64,20 +64,20 @@ galign_align(const GARigidMolInfo &self, const PyMol &query, bool flexible,
              int max_iters) {
   const Matrix3Xd &seed = galign_try_get_conf(query, conf);
 
-  check_interval(max_conf, "max_confs", Bounds::kOpenLo, 0);
-  check_interval(max_trs, "max_translation", Bounds::kClosed, 0);
-  check_interval(max_rot, "max_rotation", Bounds::kClosed, 0);
-  check_interval(max_tors, "max_torsion", Bounds::kClosed, 0);
-  check_interval(rigid_min_rmsd, "rigid_min_rmsd", Bounds::kClosed, 0);
-  check_interval(rigid_max_conf, "rigid_max_confs", Bounds::kOpenLo, 0);
-  check_interval(pool_size, "pool_size", Bounds::kOpenLo, 0);
-  check_interval(sample_size, "sample_size", Bounds::kOpenLo, 0);
-  check_interval(max_gen, "max_generations", Bounds::kOpenLo, 0);
-  check_interval(patience, "patience", Bounds::kOpenLo, 0);
-  check_interval(mut_cnt, "n_mutation", Bounds::kClosed, 0);
+  check_positive(max_conf, "max_confs");
+  check_nonneg(max_trs, "max_translation");
+  check_nonneg(max_rot, "max_rotation");
+  check_nonneg(max_tors, "max_torsion");
+  check_nonneg(rigid_min_rmsd, "rigid_min_rmsd");
+  check_positive(rigid_max_conf, "rigid_max_confs");
+  check_positive(pool_size, "pool_size");
+  check_positive(sample_size, "sample_size");
+  check_positive(max_gen, "max_generations");
+  check_positive(patience, "patience");
+  check_nonneg(mut_cnt, "n_mutation");
   check_interval(mut_prob, "p_mutation", Bounds::kClosed, 0.0, 1.0);
-  check_interval(ftol, "opt_ftol", Bounds::kOpenLo, 0);
-  check_interval(max_iters, "opt_max_iters", Bounds::kOpenLo, 0);
+  check_positive(ftol, "opt_ftol");
+  check_positive(max_iters, "opt_max_iters");
 
   GAMinimizeArgs margs;
   if (flexible) {

--- a/python/src/nuri/tools/galign_module.cpp
+++ b/python/src/nuri/tools/galign_module.cpp
@@ -156,15 +156,11 @@ Align the given query molecule to the template structure.
 :param query: The query molecule to be aligned. Must have at least one 3D
   conformation.
 :param flexible: Whether to perform flexible alignment. When ``False``, only
-  rigid alignment is performed and the flexible alignment parameters are ignored.
+  rigid alignment is performed and the flexible alignment parameters are
+  ignored, though they are still validated.
 :param max_confs: The maximum number of alignment results to return.
 :param conf: The conformation index to use as the query structure. If not
   provided, the first conformation is used.
-:param vdw_scale: The scale factor for van der Waals radii when calculating
-  shape overlap score.
-:param hetero_scale: The scale factor for atom type mismatch when calculating
-  shape overlap score.
-:param dcut: The distance cutoff for neighbor search, in angstroms.
 :param max_translation: The maximum translation allowed during flexible
   alignment, in angstroms.
 :param max_rotation: The maximum rotation allowed during flexible alignment,
@@ -236,7 +232,8 @@ Align the given query molecule to the template structure.
 :param templ: The template structure. Must have at least 3 atoms and 3D
   coordinates.
 :param flexible: Whether to perform flexible alignment. When ``False``, only
-  rigid alignment is performed and the flexible alignment parameters are ignored.
+  rigid alignment is performed and the flexible alignment parameters are
+  ignored, though they are still validated.
 :param max_confs: The maximum number of alignment results to return.
 :param qconf: The conformation index to use as the query structure. If not
   provided, the first conformation is used.

--- a/python/src/nuri/tools/tm_module.cpp
+++ b/python/src/nuri/tools/tm_module.cpp
@@ -134,8 +134,8 @@ TMAlign tmalign_init_aln(py::handle query, py::handle templ, py::handle aln,
 }
 
 void check_score_args(std::optional<int> l_norm, std::optional<double> d0) {
-  check_interval(l_norm, "l_norm", Bounds::kOpenLo, 0);
-  check_interval(d0, "d0", Bounds::kOpenLo, 0);
+  check_positive(l_norm, "l_norm");
+  check_positive(d0, "d0");
 }
 
 pyt::Tuple<py::array_t<double>, double>

--- a/python/src/nuri/tools/tm_module.cpp
+++ b/python/src/nuri/tools/tm_module.cpp
@@ -133,6 +133,11 @@ TMAlign tmalign_init_aln(py::handle query, py::handle templ, py::handle aln,
   return tmalign_try_construct_init(x, y, y2x, keep_alignment);
 }
 
+void check_score_args(std::optional<int> l_norm, std::optional<double> d0) {
+  check_positive(l_norm, "l_norm");
+  check_positive(d0, "d0");
+}
+
 pyt::Tuple<py::array_t<double>, double>
 tmalign_convert_result(const std::pair<Isometry3d, double> &result) {
   if (result.second < 0)
@@ -227,6 +232,7 @@ Prepare TM-align algorithm with the given structures and user-provided alignment
           "score",
           [](TMAlign &self, std::optional<int> l_norm,
              std::optional<double> d0) {
+            check_score_args(l_norm, d0);
             return tmalign_convert_result(
                 self.tm_score(l_norm.value_or(-1), d0.value_or(-1)));
           },
@@ -299,6 +305,7 @@ Get pairwise alignment of the query and template structures.
           std::optional<std::string_view> py_secx,
           std::optional<std::string_view> py_secy, std::optional<double> d0,
           bool gt, bool ss, bool local, bool lpss, bool fgt) {
+         check_score_args(l_norm, d0);
          TMAlign tm = tmalign_init(query, templ, py_secx, py_secy, gt, ss,
                                    local, lpss, fgt);
          return tmalign_convert_result(
@@ -364,6 +371,7 @@ Run TM-align algorithm with the given structures and parameters.
           [](py::handle query, py::handle templ, py::handle aln,
              std::optional<int> l_norm, std::optional<double> d0,
              bool keep_alignment) {
+            check_score_args(l_norm, d0);
             TMAlign tm = tmalign_init_aln(query, templ, aln, keep_alignment);
             return tmalign_convert_result(
                 tm.tm_score(l_norm.value_or(-1), d0.value_or(-1)));

--- a/python/src/nuri/tools/tm_module.cpp
+++ b/python/src/nuri/tools/tm_module.cpp
@@ -134,8 +134,8 @@ TMAlign tmalign_init_aln(py::handle query, py::handle templ, py::handle aln,
 }
 
 void check_score_args(std::optional<int> l_norm, std::optional<double> d0) {
-  check_positive(l_norm, "l_norm");
-  check_positive(d0, "d0");
+  check_interval(l_norm, "l_norm", Bounds::kLeftOpen, 0);
+  check_interval(d0, "d0", Bounds::kLeftOpen, 0);
 }
 
 pyt::Tuple<py::array_t<double>, double>

--- a/python/src/nuri/tools/tm_module.cpp
+++ b/python/src/nuri/tools/tm_module.cpp
@@ -134,8 +134,8 @@ TMAlign tmalign_init_aln(py::handle query, py::handle templ, py::handle aln,
 }
 
 void check_score_args(std::optional<int> l_norm, std::optional<double> d0) {
-  check_interval(l_norm, "l_norm", Bounds::kLeftOpen, 0);
-  check_interval(d0, "d0", Bounds::kLeftOpen, 0);
+  check_interval(l_norm, "l_norm", Bounds::kOpenLo, 0);
+  check_interval(d0, "d0", Bounds::kOpenLo, 0);
 }
 
 pyt::Tuple<py::array_t<double>, double>

--- a/python/test/algo/crdgen_test.py
+++ b/python/test/algo/crdgen_test.py
@@ -45,3 +45,8 @@ def test_crdgen_distgeom(sample: Molecule):
         )
         <= 0.1
     )
+
+
+def test_crdgen_invalid_args(sample: Molecule):
+    with pytest.raises(ValueError, match="max_trial must be positive"):
+        algo.generate_coords(sample, max_trial=0)

--- a/python/test/algo/crdgen_test.py
+++ b/python/test/algo/crdgen_test.py
@@ -48,5 +48,5 @@ def test_crdgen_distgeom(sample: Molecule):
 
 
 def test_crdgen_invalid_args(sample: Molecule):
-    with pytest.raises(ValueError, match="max_trial must be positive"):
+    with pytest.raises(ValueError, match=r"max_trial must be in \(0, inf\)"):
         algo.generate_coords(sample, max_trial=0)

--- a/python/test/algo/guess_test.py
+++ b/python/test/algo/guess_test.py
@@ -95,7 +95,11 @@ def test_guess_error(arginine: Molecule):
         with pytest.raises(ValueError, match="finite"):
             algo.guess_connectivity(mut, threshold=float("inf"))
 
-        with pytest.raises(ValueError, match="threshold must be non-negative"):
+        with pytest.raises(
+            ValueError, match=r"threshold must be in \[0, inf\)"
+        ):
             algo.guess_everything(mut, threshold=-1.0)
-        with pytest.raises(ValueError, match="threshold must be non-negative"):
+        with pytest.raises(
+            ValueError, match=r"threshold must be in \[0, inf\)"
+        ):
             algo.guess_connectivity(mut, threshold=-1.0)

--- a/python/test/algo/guess_test.py
+++ b/python/test/algo/guess_test.py
@@ -86,5 +86,16 @@ def test_guess_types(arginine_bonds: Molecule):
 
 
 def test_guess_error(arginine: Molecule):
-    with arginine.mutator() as mut, pytest.raises(IndexError):
-        algo.guess_everything(mut, 100)
+    with arginine.mutator() as mut:
+        with pytest.raises(IndexError):
+            algo.guess_everything(mut, 100)
+
+        with pytest.raises(ValueError, match="finite"):
+            algo.guess_everything(mut, threshold=float("nan"))
+        with pytest.raises(ValueError, match="finite"):
+            algo.guess_connectivity(mut, threshold=float("inf"))
+
+        with pytest.raises(ValueError, match="threshold must be non-negative"):
+            algo.guess_everything(mut, threshold=-1.0)
+        with pytest.raises(ValueError, match="threshold must be non-negative"):
+            algo.guess_connectivity(mut, threshold=-1.0)

--- a/python/test/algo/rings_test.py
+++ b/python/test/algo/rings_test.py
@@ -106,7 +106,7 @@ def test_ring_size(cubane: Molecule):
     for ring in rings:
         assert len(ring) <= 6
 
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match=r"must be in \(0, inf\)"):
         algo.find_all_rings(cubane, -1)
 
     # None means "unlimited", not a rejected value

--- a/python/test/algo/rings_test.py
+++ b/python/test/algo/rings_test.py
@@ -109,5 +109,5 @@ def test_ring_size(cubane: Molecule):
     with pytest.raises(ValueError, match="must be positive"):
         algo.find_all_rings(cubane, -1)
 
-    # None is the "unlimited" sentinel, not a rejected value
+    # None means "unlimited", not a rejected value
     assert len(algo.find_all_rings(cubane, None)) > len(rings)

--- a/python/test/algo/rings_test.py
+++ b/python/test/algo/rings_test.py
@@ -108,3 +108,6 @@ def test_ring_size(cubane: Molecule):
 
     with pytest.raises(ValueError, match="must be positive"):
         algo.find_all_rings(cubane, -1)
+
+    # None is the "unlimited" sentinel, not a rejected value
+    assert len(algo.find_all_rings(cubane, None)) > len(rings)

--- a/python/test/core/geometry_test.py
+++ b/python/test/core/geometry_test.py
@@ -328,6 +328,27 @@ class TestVoxelGrid:
         with pytest.raises(ValueError, match="must be positive"):
             grid.rebuild(pts, cutoff=0.0)
 
+    def test_too_fine_cutoff(self, cloud: tuple[np.ndarray, np.ndarray]):
+        pts, _ = cloud
+        with pytest.raises(ValueError, match="cutoff is too small"):
+            ngeom.VoxelGrid(pts, cutoff=1e-9)
+
+        grid = ngeom.VoxelGrid(pts, cutoff=1.5)
+        before = grid.find_neighbors(pts[0])
+        with pytest.raises(ValueError, match="cutoff is too small"):
+            grid.rebuild(pts, cutoff=1e-9)
+
+        # the effective cutoff is checked even when it is inherited
+        far = np.vstack([pts, [1e9, 1e9, 1e9]])
+        with pytest.raises(ValueError, match="cutoff is too small"):
+            grid.rebuild(far)
+
+        # a rejected rebuild must leave the grid as it was
+        assert grid.cutoff == pytest.approx(1.5)
+        after = grid.find_neighbors(pts[0])
+        assert np.array_equal(after[0], before[0])
+        assert np.allclose(after[1], before[1])
+
     def test_nonfinite_coords(self, cloud: tuple[np.ndarray, np.ndarray]):
         pts, query = cloud
         bad = pts.copy()

--- a/python/test/core/geometry_test.py
+++ b/python/test/core/geometry_test.py
@@ -125,7 +125,7 @@ class TestOctree:
 
         with pytest.raises(ValueError, match="NaN or infinite"):
             ngeom.Octree(bad)
-        with pytest.raises(ValueError, match="bucket size"):
+        with pytest.raises(ValueError, match="bucket_size"):
             ngeom.Octree(pts, bucket_size=0)
 
         tree = ngeom.Octree(pts)
@@ -136,9 +136,9 @@ class TestOctree:
         bad_q[0, 1] = np.inf
         with pytest.raises(ValueError, match="NaN or infinite"):
             tree.find_neighbors(bad_q, k=1)
-        with pytest.raises(ValueError, match="cutoff"):
+        with pytest.raises(ValueError, match="finite d"):
             tree.find_neighbors(query, d=np.nan)
-        with pytest.raises(ValueError, match="number of neighbors"):
+        with pytest.raises(ValueError, match=r"k must be in \(0, inf\)"):
             tree.find_neighbors(query, k=0)
 
     def test_find_neighbors_requires_d_or_k(

--- a/python/test/core/geometry_test.py
+++ b/python/test/core/geometry_test.py
@@ -258,7 +258,7 @@ class TestOctree:
     ):
         pts, _ = cloud
         tree = ngeom.Octree(pts)
-        with pytest.raises(ValueError, match="must be positive"):
+        with pytest.raises(ValueError, match=r"must be in \(0, inf\)"):
             tree.query_pairs(d=-1.0)
 
     def test_query_tree(self, cloud: tuple[np.ndarray, np.ndarray]):
@@ -280,7 +280,7 @@ class TestOctree:
         pts, qry = cloud
         tree = ngeom.Octree(pts)
         other = ngeom.Octree(qry)
-        with pytest.raises(ValueError, match="must be positive"):
+        with pytest.raises(ValueError, match=r"must be in \(0, inf\)"):
             tree.query_tree(other, d=-1.0)
 
 
@@ -315,7 +315,7 @@ class TestVoxelGrid:
         cutoff: float,
     ):
         pts, _ = cloud
-        with pytest.raises(ValueError, match="must be positive"):
+        with pytest.raises(ValueError, match=r"must be in \(0, inf\)"):
             ngeom.VoxelGrid(pts, cutoff=cutoff)
 
     def test_rebuild_invalid_cutoff(
@@ -323,9 +323,9 @@ class TestVoxelGrid:
     ):
         pts, _ = cloud
         grid = ngeom.VoxelGrid(pts, cutoff=1.5)
-        with pytest.raises(ValueError, match="must be positive"):
+        with pytest.raises(ValueError, match=r"must be in \(0, inf\)"):
             grid.rebuild(pts, cutoff=-1.0)
-        with pytest.raises(ValueError, match="must be positive"):
+        with pytest.raises(ValueError, match=r"must be in \(0, inf\)"):
             grid.rebuild(pts, cutoff=0.0)
 
     def test_too_fine_cutoff(self, cloud: tuple[np.ndarray, np.ndarray]):

--- a/python/test/core/geometry_test.py
+++ b/python/test/core/geometry_test.py
@@ -77,6 +77,16 @@ def test_align_nonfinite(method: str):
         ngeom.align_rmsd(q, t, method=method, reflection=True)
 
 
+def test_transform_nonfinite():
+    with pytest.raises(ValueError, match="NaN or infinite"):
+        ngeom.transform(np.eye(4), np.full((5, 3), np.nan))
+
+    bad_xform = np.eye(4)
+    bad_xform[0, 0] = np.inf
+    with pytest.raises(ValueError, match="NaN or infinite"):
+        ngeom.transform(bad_xform, np.zeros((5, 3)))
+
+
 @pytest.fixture(scope="module")
 def cloud():
     rng = np.random.default_rng(42)
@@ -105,6 +115,31 @@ class TestOctree:
         assert dist.shape == (5,)
         assert np.array_equal(idxs[:, 1], np.arange(5))
         assert np.allclose(dist, 0.0)
+
+    def test_nonfinite_and_invalid_args(
+        self, cloud: tuple[np.ndarray, np.ndarray]
+    ):
+        pts, query = cloud
+        bad = pts.copy()
+        bad[0, 0] = np.nan
+
+        with pytest.raises(ValueError, match="NaN or infinite"):
+            ngeom.Octree(bad)
+        with pytest.raises(ValueError, match="bucket size"):
+            ngeom.Octree(pts, bucket_size=0)
+
+        tree = ngeom.Octree(pts)
+        with pytest.raises(ValueError, match="NaN or infinite"):
+            tree.rebuild(bad)
+
+        bad_q = query.copy()
+        bad_q[0, 1] = np.inf
+        with pytest.raises(ValueError, match="NaN or infinite"):
+            tree.find_neighbors(bad_q, k=1)
+        with pytest.raises(ValueError, match="cutoff"):
+            tree.find_neighbors(query, d=np.nan)
+        with pytest.raises(ValueError, match="number of neighbors"):
+            tree.find_neighbors(query, k=0)
 
     def test_find_neighbors_requires_d_or_k(
         self, cloud: tuple[np.ndarray, np.ndarray]
@@ -292,6 +327,23 @@ class TestVoxelGrid:
             grid.rebuild(pts, cutoff=-1.0)
         with pytest.raises(ValueError, match="must be positive"):
             grid.rebuild(pts, cutoff=0.0)
+
+    def test_nonfinite_coords(self, cloud: tuple[np.ndarray, np.ndarray]):
+        pts, query = cloud
+        bad = pts.copy()
+        bad[0, 0] = np.nan
+
+        with pytest.raises(ValueError, match="NaN or infinite"):
+            ngeom.VoxelGrid(bad, cutoff=1.5)
+
+        grid = ngeom.VoxelGrid(pts, cutoff=1.5)
+        with pytest.raises(ValueError, match="NaN or infinite"):
+            grid.rebuild(bad)
+
+        bad_q = query.copy()
+        bad_q[0, 0] = np.inf
+        with pytest.raises(ValueError, match="NaN or infinite"):
+            grid.find_neighbors(bad_q)
 
     def test_find_neighbors(self, cloud: tuple[np.ndarray, np.ndarray]):
         pts, qry = cloud

--- a/python/test/core/molecule_test.py
+++ b/python/test/core/molecule_test.py
@@ -266,7 +266,7 @@ def test_update_atom(mol: Molecule):
     with pytest.raises(ValueError, match="finite partial_charge"):
         atom.partial_charge = np.inf
     with pytest.raises(
-        ValueError, match="implicit_hydrogens must be non-negative"
+        ValueError, match=r"implicit_hydrogens must be in \[0, inf\)"
     ):
         atom.implicit_hydrogens = -1
 

--- a/python/test/core/molecule_test.py
+++ b/python/test/core/molecule_test.py
@@ -183,6 +183,9 @@ def test_add_conformer():
     with pytest.raises(ValueError, match="different number of atoms"):
         mol.add_conf(np.arange(9).reshape(3, 3))
 
+    with pytest.raises(ValueError, match="NaN or infinite"):
+        mol.add_conf(np.full((2, 3), np.nan))
+
     assert mol.num_confs() == 1
 
     conf = mol.get_conf()
@@ -257,6 +260,15 @@ def test_update_atom(mol: Molecule):
 
     atom.aromatic = True
     assert atom.aromatic
+
+    with pytest.raises(ValueError, match="finite partial_charge"):
+        atom.update(partial_charge=np.nan)
+    with pytest.raises(ValueError, match="finite partial_charge"):
+        atom.partial_charge = np.inf
+    with pytest.raises(
+        ValueError, match="implicit_hydrogens must be non-negative"
+    ):
+        atom.implicit_hydrogens = -1
 
 
 def test_update_bond(mol: Molecule):
@@ -468,6 +480,9 @@ def test_set_conformer(mol3d: Molecule):
     assert np.allclose(atom.get_pos(), [400, 500, 600])
     assert np.allclose(mol3d.get_conf()[1], [400, 500, 600])
 
+    with pytest.raises(ValueError, match="NaN or infinite"):
+        mol3d.set_conf(np.full_like(conf, np.inf))
+
 
 def test_add_conformer_index(mol3d: Molecule):
     conf = np.zeros((mol3d.num_atoms(), 3))
@@ -538,6 +553,9 @@ def test_bond_rotation(mol3d: Molecule):
     assert np.allclose(mol3d.get_conf(), rotated, atol=1e-3)
     bond.rotate(-30, True)
     assert np.allclose(mol3d.get_conf(), original, atol=1e-3)
+
+    with pytest.raises(ValueError, match="finite"):
+        bond.rotate(np.nan)
 
 
 def test_clear_conformers(mol3d: Molecule):

--- a/python/test/core/substructure_test.py
+++ b/python/test/core/substructure_test.py
@@ -529,6 +529,11 @@ def test_pop_substruct(molsub: Molecule):
     assert len(subs) == 0
     assert len(sub) == 3
 
+    with pytest.raises(IndexError):
+        subs.pop()
+    with pytest.raises(IndexError):
+        subs.pop(0)
+
 
 def test_clear_substruct(molsub: Molecule):
     subs = molsub.subs

--- a/python/test/desc/surface_test.py
+++ b/python/test/desc/surface_test.py
@@ -107,10 +107,10 @@ def test_sr_sasa_errors(phenol: Molecule):
     with pytest.raises(ValueError, match="number of points"):
         shrake_rupley_sasa(pts, radii[:-1])
 
-    with pytest.raises(ValueError, match="number of probes"):
+    with pytest.raises(ValueError, match="nprobe"):
         shrake_rupley_sasa(pts, radii, nprobe=0)
 
-    with pytest.raises(ValueError, match="radius of probes"):
+    with pytest.raises(ValueError, match="rprobe"):
         shrake_rupley_sasa(pts, radii, rprobe=-1.0)
 
     radii[-2] = -1.0

--- a/python/test/desc/surface_test.py
+++ b/python/test/desc/surface_test.py
@@ -116,3 +116,8 @@ def test_sr_sasa_errors(phenol: Molecule):
     radii[-2] = -1.0
     with pytest.raises(ValueError, match="radii must be positive"):
         shrake_rupley_sasa(pts, radii)
+
+    radii[-2] = 1.0
+    pts[0, 0] = np.nan
+    with pytest.raises(ValueError, match="NaN or infinite"):
+        shrake_rupley_sasa(pts, radii)

--- a/python/test/fmt/cif_test.py
+++ b/python/test/fmt/cif_test.py
@@ -360,14 +360,14 @@ def test_cif_column_format():
     with pytest.raises(TypeError):
         ColumnFormat(4)  # keyword-only
 
-    # an unbounded width would zero-pad into a multi-gigabyte string, and a
-    # width of 1 or less never pads at all
-    for bad in (-1, 0, 1, 81, 2**31 - 1):
-        with pytest.raises(ValueError, match=r"width must be in \(1, 80\]"):
+    # an unbounded width would zero-pad into a multi-gigabyte string
+    for bad in (-1, 0, 81, 2**31 - 1):
+        with pytest.raises(ValueError, match=r"width must be in \[1, 80\]"):
             ColumnFormat(width=bad)
-        with pytest.raises(ValueError, match=r"width must be in \(1, 80\]"):
+        with pytest.raises(ValueError, match=r"width must be in \[1, 80\]"):
             Value(3, width=bad)
 
+    assert ColumnFormat(width=1).width == 1
     assert ColumnFormat(width=80).width == 80
     assert ColumnFormat().width is None
     assert "width=None" in repr(ColumnFormat())

--- a/python/test/fmt/cif_test.py
+++ b/python/test/fmt/cif_test.py
@@ -355,7 +355,7 @@ def test_cif_column_format():
         ColumnFormat(bogus=True)
     with pytest.raises(ValueError, match="null_token"):
         ColumnFormat(null_token="x")
-    with pytest.raises(ValueError, match="precision must be non-negative"):
+    with pytest.raises(ValueError, match=r"precision must be in \[0, inf\)"):
         ColumnFormat(precision=-1)
     with pytest.raises(TypeError):
         ColumnFormat(4)  # keyword-only

--- a/python/test/fmt/cif_test.py
+++ b/python/test/fmt/cif_test.py
@@ -336,7 +336,7 @@ def test_cif_table_column_formats():
 
 def test_cif_column_format():
     fmt = ColumnFormat()
-    assert fmt.width == 0
+    assert fmt.width is None
     assert fmt.precision is None
     assert fmt.raw is False
     assert fmt.short_form is False
@@ -360,14 +360,17 @@ def test_cif_column_format():
     with pytest.raises(TypeError):
         ColumnFormat(4)  # keyword-only
 
-    # an unbounded width would zero-pad into a multi-gigabyte string
-    for bad in (-1, 81, 2**31 - 1):
-        with pytest.raises(ValueError, match=r"width must be in \[0, 80\]"):
+    # an unbounded width would zero-pad into a multi-gigabyte string, and a
+    # width of 1 or less never pads at all
+    for bad in (-1, 0, 1, 81, 2**31 - 1):
+        with pytest.raises(ValueError, match=r"width must be in \(1, 80\]"):
             ColumnFormat(width=bad)
-        with pytest.raises(ValueError, match=r"width must be in \[0, 80\]"):
+        with pytest.raises(ValueError, match=r"width must be in \(1, 80\]"):
             Value(3, width=bad)
 
     assert ColumnFormat(width=80).width == 80
+    assert ColumnFormat().width is None
+    assert "width=None" in repr(ColumnFormat())
 
 
 def test_cif_table_column_formats_strict():

--- a/python/test/fmt/cif_test.py
+++ b/python/test/fmt/cif_test.py
@@ -360,6 +360,15 @@ def test_cif_column_format():
     with pytest.raises(TypeError):
         ColumnFormat(4)  # keyword-only
 
+    # an unbounded width would zero-pad into a multi-gigabyte string
+    for bad in (-1, 81, 2**31 - 1):
+        with pytest.raises(ValueError, match=r"width must be in \[0, 80\]"):
+            ColumnFormat(width=bad)
+        with pytest.raises(ValueError, match=r"width must be in \[0, 80\]"):
+            Value(3, width=bad)
+
+    assert ColumnFormat(width=80).width == 80
+
 
 def test_cif_table_column_formats_strict():
     with pytest.raises(ValueError, match="Unknown key in column_formats"):

--- a/python/test/fmt/mol2_test.py
+++ b/python/test/fmt/mol2_test.py
@@ -110,8 +110,7 @@ def test_mol2_file(tmp_path: Path):
 
 
 def test_mol2_nonfinite():
-    # Parsers accept "nan"/"inf" coordinate text; the reader must reject the
-    # resulting molecule instead of yielding non-finite coordinates.
+    # The parser itself accepts "nan"/"inf" coordinate text
     data = """\
 @<TRIPOS>MOLECULE
 Nan
@@ -125,7 +124,6 @@ NO_CHARGES
     with pytest.raises(ValueError, match="non-finite"):
         list(nuri.readstring("mol2", data))
 
-    # skip_on_error should drop it silently instead of raising
     assert list(nuri.readstring("mol2", data, skip_on_error=True)) == []
 
 

--- a/python/test/fmt/mol2_test.py
+++ b/python/test/fmt/mol2_test.py
@@ -109,6 +109,26 @@ def test_mol2_file(tmp_path: Path):
     _verify_mols(mols)
 
 
+def test_mol2_nonfinite():
+    # Parsers accept "nan"/"inf" coordinate text; the reader must reject the
+    # resulting molecule instead of yielding non-finite coordinates.
+    data = """\
+@<TRIPOS>MOLECULE
+Nan
+ 1 0 0 0 0
+SMALL
+NO_CHARGES
+
+@<TRIPOS>ATOM
+ 1 C1            nan    0.0000    0.0000 C.3
+"""
+    with pytest.raises(ValueError, match="non-finite"):
+        list(nuri.readstring("mol2", data))
+
+    # skip_on_error should drop it silently instead of raising
+    assert list(nuri.readstring("mol2", data, skip_on_error=True)) == []
+
+
 def test_mol2_str():
     mols = list(nuri.readstring("mol2", mol2_data))
     _verify_mols(mols)

--- a/python/test/tools/chimera_test.py
+++ b/python/test/tools/chimera_test.py
@@ -86,6 +86,15 @@ def test_match_maker_errors(query: np.ndarray, templ: np.ndarray):
     ):
         chimera.match_maker(query, templ, viol_ratio=1.5)
 
+    # Lower bound is exclusive here, unlike galign's p_mutation
+    with pytest.raises(
+        ValueError, match="global_ratio must be between 0 and 1"
+    ):
+        chimera.match_maker(query, templ, global_ratio=0.0)
+
+    with pytest.raises(ValueError, match="finite"):
+        chimera.match_maker(query, templ, global_ratio=np.nan)
+
     query[0] = np.nan
-    with pytest.raises(RuntimeError, match="alignment failed"):
+    with pytest.raises(ValueError, match="NaN or infinite"):
         chimera.match_maker(query, templ)

--- a/python/test/tools/chimera_test.py
+++ b/python/test/tools/chimera_test.py
@@ -71,7 +71,7 @@ def test_match_maker_errors(query: np.ndarray, templ: np.ndarray):
     with pytest.raises(ValueError, match="have different number of points"):
         chimera.match_maker(query[:3], templ)
 
-    with pytest.raises(ValueError, match="cutoff must be positive"):
+    with pytest.raises(ValueError, match=r"cutoff must be in \(0, inf\)"):
         chimera.match_maker(query, templ, -1)
 
     with pytest.raises(

--- a/python/test/tools/chimera_test.py
+++ b/python/test/tools/chimera_test.py
@@ -76,20 +76,17 @@ def test_match_maker_errors(query: np.ndarray, templ: np.ndarray):
 
     with pytest.raises(
         ValueError,
-        match="global_ratio must be between 0 and 1",
+        match=r"global_ratio must be in \(0, 1\]",
     ):
         chimera.match_maker(query, templ, global_ratio=1.5)
 
     with pytest.raises(
         ValueError,
-        match="viol_ratio must be between 0 and 1",
+        match=r"viol_ratio must be in \(0, 1\]",
     ):
         chimera.match_maker(query, templ, viol_ratio=1.5)
 
-    # Lower bound is exclusive here, unlike galign's p_mutation
-    with pytest.raises(
-        ValueError, match="global_ratio must be between 0 and 1"
-    ):
+    with pytest.raises(ValueError, match=r"global_ratio must be in \(0, 1\]"):
         chimera.match_maker(query, templ, global_ratio=0.0)
 
     with pytest.raises(ValueError, match="finite"):

--- a/python/test/tools/galign_test.py
+++ b/python/test/tools/galign_test.py
@@ -140,14 +140,16 @@ def test_galign_sampling_args_validation(
     templ: Molecule, query: Molecule
 ) -> None:
     # Sampling args are validated even when `flexible` is False
-    with pytest.raises(ValueError, match="pool_size must be positive"):
+    with pytest.raises(ValueError, match=r"pool_size must be in \(0, inf\)"):
         galign(query, templ, pool_size=0)
-    with pytest.raises(ValueError, match="patience must be positive"):
+    with pytest.raises(ValueError, match=r"patience must be in \(0, inf\)"):
         galign(query, templ, patience=0)
-    with pytest.raises(ValueError, match="rigid_max_confs must be positive"):
+    with pytest.raises(
+        ValueError, match=r"rigid_max_confs must be in \(0, inf\)"
+    ):
         galign(query, templ, rigid_max_confs=0)
     with pytest.raises(
-        ValueError, match="rigid_min_rmsd must be non-negative"
+        ValueError, match=r"rigid_min_rmsd must be in \[0, inf\)"
     ):
         galign(query, templ, rigid_min_rmsd=-1.0)
 

--- a/python/test/tools/galign_test.py
+++ b/python/test/tools/galign_test.py
@@ -147,8 +147,10 @@ def test_galign_sampling_args_validation(
         galign(query, templ, patience=0)
     with pytest.raises(ValueError, match="rigid_max_confs must be positive"):
         galign(query, templ, rigid_max_confs=0)
-    with pytest.raises(ValueError, match="rigid_min_msd must be non-negative"):
-        galign(query, templ, rigid_min_msd=-1.0)
+    with pytest.raises(
+        ValueError, match="rigid_min_rmsd must be non-negative"
+    ):
+        galign(query, templ, rigid_min_rmsd=-1.0)
 
     # Lower bound is inclusive here, unlike chimera's global_ratio
     assert galign(query, templ, flexible=False, p_mutation=0.0, n_mutation=0)

--- a/python/test/tools/galign_test.py
+++ b/python/test/tools/galign_test.py
@@ -127,3 +127,28 @@ def test_flexible_galign(
         atol=1e-6,
     )
     assert result.score >= 0.95
+
+
+def test_galign_nonfinite(templ: Molecule, query: Molecule) -> None:
+    with pytest.raises(ValueError, match="finite"):
+        galign(query, templ, vdw_scale=float("nan"))
+    with pytest.raises(ValueError, match="finite"):
+        galign(query, templ, flexible=True, opt_ftol=float("nan"))
+
+
+def test_galign_sampling_args_validation(
+    templ: Molecule, query: Molecule
+) -> None:
+    # These reach GASamplingArgs even in rigid mode, so they are validated
+    # regardless of `flexible`.
+    with pytest.raises(ValueError, match="pool_size must be positive"):
+        galign(query, templ, pool_size=0)
+    with pytest.raises(ValueError, match="patience must be positive"):
+        galign(query, templ, patience=0)
+    with pytest.raises(ValueError, match="rigid_max_confs must be positive"):
+        galign(query, templ, rigid_max_confs=0)
+    with pytest.raises(ValueError, match="rigid_min_msd must be non-negative"):
+        galign(query, templ, rigid_min_msd=-1.0)
+
+    # Lower bound is inclusive here, unlike chimera's global_ratio
+    assert galign(query, templ, flexible=False, p_mutation=0.0, n_mutation=0)

--- a/python/test/tools/galign_test.py
+++ b/python/test/tools/galign_test.py
@@ -139,8 +139,7 @@ def test_galign_nonfinite(templ: Molecule, query: Molecule) -> None:
 def test_galign_sampling_args_validation(
     templ: Molecule, query: Molecule
 ) -> None:
-    # These reach GASamplingArgs even in rigid mode, so they are validated
-    # regardless of `flexible`.
+    # Sampling args are validated even when `flexible` is False
     with pytest.raises(ValueError, match="pool_size must be positive"):
         galign(query, templ, pool_size=0)
     with pytest.raises(ValueError, match="patience must be positive"):
@@ -152,5 +151,5 @@ def test_galign_sampling_args_validation(
     ):
         galign(query, templ, rigid_min_rmsd=-1.0)
 
-    # Lower bound is inclusive here, unlike chimera's global_ratio
+    # p_mutation's lower bound is inclusive
     assert galign(query, templ, flexible=False, p_mutation=0.0, n_mutation=0)

--- a/python/test/tools/tm_test.py
+++ b/python/test/tools/tm_test.py
@@ -237,16 +237,13 @@ def test_tm_errors():
 
 
 def test_tm_short_secstr():
-    # Secondary-structure assignment on a structure shorter than the
-    # 5-residue window must raise, not crash (regression: out-of-bounds
-    # indexing when one secondary structure is inferred).
+    # Regression: the inferred template ss indexed out of bounds before raising
     with pytest.raises(ValueError, match="at least 5 residues"):
         tmtools.TMAlign(np.zeros((5, 3)), np.zeros((3, 3)), query_ss="CCCCC")
 
 
 def test_tm_invalid_score_args(query: np.ndarray, templ: np.ndarray):
-    # None already means "auto"; a non-positive value used to be silently
-    # reinterpreted as such instead of raising.
+    # None already means "auto"; non-positive used to be silently reinterpreted
     with pytest.raises(ValueError, match="d0 must be positive"):
         tmtools.tm_align(query, templ, d0=0.0)
     with pytest.raises(ValueError, match="l_norm must be positive"):

--- a/python/test/tools/tm_test.py
+++ b/python/test/tools/tm_test.py
@@ -234,3 +234,11 @@ def test_tm_errors():
 
     with pytest.raises(ValueError, match="must have the same length"):
         tmtools.tm_score(np.zeros((11, 3)), np.zeros((10, 3)))
+
+
+def test_tm_short_secstr():
+    # Secondary-structure assignment on a structure shorter than the
+    # 5-residue window must raise, not crash (regression: out-of-bounds
+    # indexing when one secondary structure is inferred).
+    with pytest.raises(ValueError, match="at least 5 residues"):
+        tmtools.TMAlign(np.zeros((5, 3)), np.zeros((3, 3)), query_ss="CCCCC")

--- a/python/test/tools/tm_test.py
+++ b/python/test/tools/tm_test.py
@@ -244,15 +244,15 @@ def test_tm_short_secstr():
 
 def test_tm_invalid_score_args(query: np.ndarray, templ: np.ndarray):
     # None already means "auto"; non-positive used to be silently reinterpreted
-    with pytest.raises(ValueError, match="d0 must be positive"):
+    with pytest.raises(ValueError, match=r"d0 must be in \(0, inf\)"):
         tmtools.tm_align(query, templ, d0=0.0)
-    with pytest.raises(ValueError, match="l_norm must be positive"):
+    with pytest.raises(ValueError, match=r"l_norm must be in \(0, inf\)"):
         tmtools.tm_align(query, templ, l_norm=0)
-    with pytest.raises(ValueError, match="l_norm must be positive"):
+    with pytest.raises(ValueError, match=r"l_norm must be in \(0, inf\)"):
         tmtools.tm_score(query, templ, l_norm=-1)
 
     tm = tmtools.TMAlign(query, templ)
-    with pytest.raises(ValueError, match="l_norm must be positive"):
+    with pytest.raises(ValueError, match=r"l_norm must be in \(0, inf\)"):
         tm.score(0)
 
 

--- a/python/test/tools/tm_test.py
+++ b/python/test/tools/tm_test.py
@@ -242,3 +242,28 @@ def test_tm_short_secstr():
     # indexing when one secondary structure is inferred).
     with pytest.raises(ValueError, match="at least 5 residues"):
         tmtools.TMAlign(np.zeros((5, 3)), np.zeros((3, 3)), query_ss="CCCCC")
+
+
+def test_tm_invalid_score_args(query: np.ndarray, templ: np.ndarray):
+    # None already means "auto"; a non-positive value used to be silently
+    # reinterpreted as such instead of raising.
+    with pytest.raises(ValueError, match="d0 must be positive"):
+        tmtools.tm_align(query, templ, d0=0.0)
+    with pytest.raises(ValueError, match="l_norm must be positive"):
+        tmtools.tm_align(query, templ, l_norm=0)
+    with pytest.raises(ValueError, match="l_norm must be positive"):
+        tmtools.tm_score(query, templ, l_norm=-1)
+
+    tm = tmtools.TMAlign(query, templ)
+    with pytest.raises(ValueError, match="l_norm must be positive"):
+        tm.score(0)
+
+
+def test_tm_nonfinite(query: np.ndarray, templ: np.ndarray):
+    with pytest.raises(ValueError, match="finite"):
+        tmtools.tm_align(query, templ, d0=float("nan"))
+
+    bad = query.copy()
+    bad[0, 0] = np.inf
+    with pytest.raises(ValueError, match="NaN or infinite"):
+        tmtools.tm_align(bad, templ)

--- a/src/core/geometry/octree.cpp
+++ b/src/core/geometry/octree.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <absl/base/attributes.h>
+#include <absl/base/optimization.h>
 #include <absl/log/absl_check.h>
 #include <absl/log/absl_log.h>
 #include <absl/types/span.h>
@@ -24,6 +25,10 @@ namespace nuri {
 namespace {
   using internal::Array8i;
   using internal::OCTreeNode;
+
+  // Sentinel values stored in OCTreeNode::children_[i].
+  constexpr int kNoChild = -1;     // octant i is empty
+  constexpr int kLeafMarker = -2;  // in children_[0] only: unsplittable leaf
 
   // Octant index is (xyz):
   // 000 -> +++, 100 -> -++, 010 -> +-+, 110 -> --+,
@@ -90,7 +95,8 @@ namespace {
 
   int build_octree(OCTree::Points pts, std::vector<OCTreeNode> &data,
                    const Vector3d &max, const Vector3d &size, ArrayXi &idxs,
-                   const int begin, const int nleaf, const int bucket_size) {
+                   const int begin, const int nleaf, const int bucket_size,
+                   int &max_nleaf) {
     Array8i children;
     auto epilog = [&]() {
       int id = static_cast<int>(data.size());
@@ -98,14 +104,27 @@ namespace {
       return id;
     };
 
-    if (nleaf <= bucket_size) {
+    auto mark_leaf = [&]() {
       std::sort(idxs.begin() + begin, idxs.begin() + begin + nleaf);
+      children[0] = kLeafMarker;
+    };
+
+    if (nleaf <= bucket_size) {
+      mark_leaf();
       return epilog();
     }
 
     Vector3d half = size * 0.5;
-    Array8i ptrs =
-        partition_octant(idxs, begin, begin + nleaf, pts, max - half);
+    Vector3d cntr = max - half;
+
+    // This bounds the recursion at floating-point precision
+    if (ABSL_PREDICT_FALSE((cntr.array() == max.array()).all())) {
+      mark_leaf();
+      max_nleaf = nuri::max(max_nleaf, nleaf);
+      return epilog();
+    }
+
+    Array8i ptrs = partition_octant(idxs, begin, begin + nleaf, pts, cntr);
 
     int right = begin;
     for (int i = 0; i < 8; ++i) {
@@ -114,31 +133,47 @@ namespace {
 
       int nchild = right - left;
       if (nchild <= 0) {
-        children[i] = -1;
+        children[i] = kNoChild;
         continue;
       }
 
       children[i] = build_octree(pts, data, max_of(i, max, half), half, idxs,
-                                 left, nchild, bucket_size);
+                                 left, nchild, bucket_size, max_nleaf);
     }
 
     return epilog();
   }
 }  // namespace
 
+bool internal::OCTreeNode::leaf() const {
+  return children_[0] == kLeafMarker;
+}
+
 void OCTree::rebuild_impl(Points src) {
-  bucket_size_ = std::max(8, bucket_size_);
+  bucket_size_ = nuri::max(8, bucket_size_);
+  nodes_.clear();
+
+  const int n = static_cast<int>(src.cols());
+  if (n == 0) {
+    max_.setZero();
+    len_.setZero();
+    idxs_.resize(0);
+    pts_.resize(3, 0);
+    max_nleaf_ = 0;
+    return;
+  }
 
   max_ = src.rowwise().maxCoeff();
   len_ = max_ - src.rowwise().minCoeff();
 
-  idxs_.resize(src.cols());
+  idxs_.resize(n);
   std::iota(idxs_.begin(), idxs_.end(), 0);
 
+  max_nleaf_ = bucket_size_;
   {
     internal::AllowEigenMallocScoped<false> ems;
-    build_octree(src, nodes_, max_, len_, idxs_, 0,
-                 static_cast<int>(src.cols()), bucket_size_);
+    build_octree(src, nodes_, max_, len_, idxs_, 0, n, bucket_size_,
+                 max_nleaf_);
   }
 
   pts_ = src(E::all, idxs_);
@@ -197,10 +232,6 @@ namespace {
     return octant_distsq;
   }
 
-  bool leaf_node(const OCTree &tree, const OCTreeNode &node) {
-    return node.nleaf() <= tree.bucket_size();
-  }
-
   double maxsq_box_point(const Vector3d &box_max, const Vector3d &box_len,
                          const Vector3d &pt) {
     Vector3d box_min = box_max - box_len;
@@ -221,6 +252,8 @@ void OCTree::find_neighbors_kd(const Vector3d &pt, const int k,
     ABSL_LOG(WARNING) << "k is not a positive number: " << k;
     return;
   }
+  if (nodes_.empty())
+    return;
   if (k > pts().cols()) {
     ABSL_LOG(WARNING)
         << "k " << k << " is larger than the number of points " << pts().cols();
@@ -233,7 +266,7 @@ void OCTree::find_neighbors_kd(const Vector3d &pt, const int k,
     worst_dsq = maxsq_box_point(max_, len_, pt);
   }
 
-  ArrayXd dsqbuf(bucket_size_);
+  ArrayXd dsqbuf(max_nleaf());
 
   NodeHeap node_heap(node_cmp);
   CandHeap best_heap(cand_cmp);
@@ -247,7 +280,7 @@ void OCTree::find_neighbors_kd(const Vector3d &pt, const int k,
       break;
 
     const OCTreeNode &node = nodes()[idx];
-    if (leaf_node(*this, node)) {
+    if (node.leaf()) {
       const int cnt = node.nleaf();
       dsqbuf.head(cnt) = (pts().middleCols(node.begin(), cnt).colwise() - pt)
                              .colwise()
@@ -298,7 +331,7 @@ namespace {
                          std::vector<double> &distsq, const OCTreeNode &node,
                          const Vector3d &maxs, const Vector3d &size,
                          ArrayXd &dsqbuf) {
-    if (leaf_node(oct, node)) {
+    if (node.leaf()) {
       const int cnt = node.nleaf();
       dsqbuf.head(cnt) =
           (oct.pts().middleCols(node.begin(), cnt).colwise() - pt)
@@ -334,8 +367,10 @@ void OCTree::find_neighbors_d(const Vector3d &pt, const double cutoff,
 
   idxs.clear();
   distsq.clear();
+  if (nodes_.empty())
+    return;
 
-  ArrayXd dsqbuf(bucket_size_);
+  ArrayXd dsqbuf(max_nleaf());
   find_candidates_d(*this, pt, cutoffsq, idxs, distsq, node(root()), max_, len_,
                     dsqbuf);
 
@@ -379,7 +414,7 @@ namespace {
                        half);
     }
 
-    bool leaf_node() const { return nuri::leaf_node(tree(), node()); }
+    bool leaf_node() const { return node().leaf(); }
 
     absl::Span<const int> idxs() const {
       ABSL_DCHECK_GE(id(), 0);
@@ -547,9 +582,12 @@ void OCTree::find_neighbors_tree(const OCTree &oct, const double cutoff,
 
   self.clear();
   other.clear();
+  if (nodes_.empty() || oct.nodes_.empty())
+    return;
 
-  VectorXd dsqbuf(oct.bucket_size_);
-  ArrayXi jbuf(oct.bucket_size_);
+  const int cap = nuri::max(max_nleaf(), oct.max_nleaf());
+  VectorXd dsqbuf(cap);
+  ArrayXi jbuf(cap);
 
   find_neighbors_tree_impl<false>(self, other, dsqbuf, jbuf, OCTreeBox(*this),
                                   OCTreeBox(oct), cutoffsq);
@@ -573,9 +611,11 @@ void OCTree::find_neighbors_self(double cutoff, std::vector<int> &left,
 
   left.clear();
   right.clear();
+  if (nodes_.empty())
+    return;
 
-  VectorXd dsqbuf(bucket_size_);
-  ArrayXi jbuf(bucket_size_);
+  VectorXd dsqbuf(max_nleaf());
+  ArrayXi jbuf(max_nleaf());
 
   OCTreeBox root(*this);
   find_neighbors_tree_impl<true>(left, right, dsqbuf, jbuf, root, root,

--- a/src/core/geometry/octree.cpp
+++ b/src/core/geometry/octree.cpp
@@ -624,7 +624,8 @@ void OCTree::find_neighbors_self(double cutoff, std::vector<int> &left,
 
 void OCTree::notify_transform(const Vector3d &new_max,
                               const Vector3d &new_len) {
-  Vector3d scale = new_len.cwiseQuotient(len_);
+  Vector3d scale =
+      (len_.array() > 0).select(new_len.array() / len_.array(), 1.0);
   Vector3d trs = new_max - max_.cwiseProduct(scale);
 
   max_ = new_max;

--- a/src/core/geometry/octree.cpp
+++ b/src/core/geometry/octree.cpp
@@ -26,9 +26,8 @@ namespace {
   using internal::Array8i;
   using internal::OCTreeNode;
 
-  // Sentinel values stored in OCTreeNode::children_[i].
-  constexpr int kNoChild = -1;     // octant i is empty
-  constexpr int kLeafMarker = -2;  // in children_[0] only: unsplittable leaf
+  constexpr int kNoChild = -1;
+  constexpr int kLeafMarker = -2;  // children_[0] only
 
   // Octant index is (xyz):
   // 000 -> +++, 100 -> -++, 010 -> +-+, 110 -> --+,
@@ -117,7 +116,7 @@ namespace {
     Vector3d half = size * 0.5;
     Vector3d cntr = max - half;
 
-    // This bounds the recursion at floating-point precision
+    // Bounds the recursion at floating-point precision
     if (ABSL_PREDICT_FALSE((cntr.array() == max.array()).all())) {
       mark_leaf();
       max_nleaf = nuri::max(max_nleaf, nleaf);

--- a/src/core/geometry/voxel_grid.cpp
+++ b/src/core/geometry/voxel_grid.cpp
@@ -3,10 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <limits>
 #include <vector>
 
 #include <absl/base/attributes.h>
+#include <absl/base/optimization.h>
 #include <absl/log/absl_check.h>
+#include <absl/log/absl_log.h>
 #include <Eigen/Dense>
 
 #include "nuri/eigen_config.h"
@@ -30,12 +33,31 @@ void VoxelGrid::rebuild_impl(Points src) {
     dims_.setZero();
     cell_offset_.setZero(1);
     cell_pts_.resize(0);
+    max_occ_ = 0;
     return;
   }
 
   origin_ = src.rowwise().minCoeff();
   Vector3d extent = src.rowwise().maxCoeff() - origin_;
-  dims_ = (extent.array() / cutoff_).ceil().cast<int>().max(1);
+
+  Array3d dims = (extent.array() / cutoff_).ceil().max(1.0);
+  const double req = dims.prod();
+
+  // 1000 is headroom for the arithmetic below; an overflowing count always
+  // overshoots by orders of magnitude, so nothing realistic lands in between
+  if (ABSL_PREDICT_FALSE(req > std::numeric_limits<int>::max() - 1e3)) {
+    const double prev = cutoff_;
+    // safety margin against floating-point rounding errors
+    cutoff_ = extent.maxCoeff() * 1.01;
+    dims.setOnes();
+
+    ABSL_LOG(WARNING) << "Cutoff " << prev
+                      << " would overflow the number of voxels for the given "
+                         "points; widening it to "
+                      << cutoff_;
+  }
+
+  dims_ = dims.cast<int>();
   const int ncells = dims_.prod();
 
   cell_offset_.setZero(ncells + 1);

--- a/src/core/molecule/addh.cpp
+++ b/src/core/molecule/addh.cpp
@@ -674,7 +674,7 @@ namespace internal {
             rvdw_sq_inv_(mol.size()),  //
             mol_(&mol), conf_(&conf), free_hs_(&free_hs) {
         for (int h = 0; h < free_hs.size(); ++h)
-          opt_blsq_inv_[h] = 1 / xh_blsq(current, h);
+          opt_blsq_inv_[h] = safe_reciprocal(xh_blsq(current, h));
 
         ArrayXi free_h_inv = ArrayXi::Constant(mol.num_atoms(), -1);
         for (int h = 0; h < free_hs.size(); ++h)
@@ -705,12 +705,14 @@ namespace internal {
             bool near = mol.find_bond(j, k) != mol.bond_end();
             if (k_h > h) {
               if (near) {
-                neighbors(h).free_near.push_back({ k_h, 1 / dsqbuf[ki] });
+                neighbors(h).free_near.push_back(
+                    { k_h, safe_reciprocal(dsqbuf[ki]) });
               } else {
                 neighbors(h).free_far.push_back(k_h);
               }
             } else if (near && !free_h) {
-              neighbors(h).fixed_near.push_back({ k, 1 / dsqbuf[ki] });
+              neighbors(h).fixed_near.push_back(
+                  { k, safe_reciprocal(dsqbuf[ki]) });
             }
 
             ++ki;

--- a/src/tools/galign/flexible.cpp
+++ b/src/tools/galign/flexible.cpp
@@ -390,6 +390,13 @@ namespace internal {
     for (GeneticConf &conf: pool)
       minimize_one_conf(conf, nm, simplex, inv, buf);
 
+    // Only the first pool_size entries seed the generations, and the resize
+    // below drops the rest, so the best must come first
+    if (static_cast<int>(pool.size()) > sampling.pool_size) {
+      std::nth_element(pool.begin(), pool.begin() + sampling.pool_size - 1,
+                       pool.end(), std::greater<>());
+    }
+
     const std::vector<GeneticConf> initial_pool(pool);
     ArrayXd cutoffs(sampling.pool_size * 2);
     exp_cumsum_scores(cutoffs.head(sampling.pool_size), initial_pool);

--- a/src/tools/galign/flexible.cpp
+++ b/src/tools/galign/flexible.cpp
@@ -419,6 +419,7 @@ namespace internal {
       prev_max = current_max;
     }
 
+    max_conf = nuri::min(max_conf, static_cast<int>(pool.size()));
     auto topk = argpartition(pool, max_conf, std::greater<>());
 
     std::vector<GAlignResult> flex_result;

--- a/src/tools/galign/prep.cpp
+++ b/src/tools/galign/prep.cpp
@@ -161,10 +161,11 @@ namespace internal {
     auto [pf, roots] = parent_forest(mol);
     std::vector rbs = split_components_by_bridge(pf, roots);
 
-    std::vector<GARotationInfo> ri(rbs.size());
+    std::vector<GARotationInfo> ri;
+    ri.reserve(rbs.size());
     for (int i = 0; i < rbs.size(); ++i) {
       RotatableBondComp &rb = rbs[i];
-      GARotationInfo &r = ri[i];
+      GARotationInfo r;
 
       const bool reverse = rb.right_atoms.size() < rb.left_atoms.size();
       (reverse ? std::tie(r.ref_, r.origin_) : std::tie(r.origin_, r.ref_)) =
@@ -172,6 +173,9 @@ namespace internal {
 
       r.normalizer_ =
           safe_normalizer((ref.col(r.origin_) - ref.col(r.ref_)).squaredNorm());
+      // Coincident endpoints have no axis; rotating about it would scale
+      if (r.normalizer_ <= 0)
+        continue;
 
       std::vector<int> &moving = reverse ? rb.right_atoms : rb.left_atoms;
       auto pit =
@@ -182,6 +186,8 @@ namespace internal {
       r.moving_ = Eigen::Map<ArrayXi>(
           moving.data(), static_cast<Eigen::Index>(moving.size() - 1));
       absl::c_sort(r.moving_);
+
+      ri.push_back(std::move(r));
     }
 
     return ri;

--- a/src/tools/galign/prep.cpp
+++ b/src/tools/galign/prep.cpp
@@ -170,7 +170,8 @@ namespace internal {
       (reverse ? std::tie(r.ref_, r.origin_) : std::tie(r.origin_, r.ref_)) =
           pf.edge_data(i);
 
-      r.normalizer_ = 1 / (ref.col(r.origin_) - ref.col(r.ref_)).norm();
+      r.normalizer_ =
+          safe_normalizer((ref.col(r.origin_) - ref.col(r.ref_)).squaredNorm());
 
       std::vector<int> &moving = reverse ? rb.right_atoms : rb.left_atoms;
       auto pit =

--- a/src/tools/tm.cpp
+++ b/src/tools/tm.cpp
@@ -55,6 +55,12 @@ namespace internal {
   ArrayXc assign_secstr_approx_full(ConstRef<Matrix3Xd> pts, Matrix3Xd &buf) {
     const int n = static_cast<int>(pts.cols());
 
+    // Classification needs 5-residue windows; for shorter inputs the indexing
+    // below would run out of bounds (e.g. dists.col(n - 4) for n < 4). Return
+    // all-coil - TM-align rejects structures with fewer than 5 residues anyway.
+    if (n < 5)
+      return ArrayXc::Constant(n, static_cast<std::int8_t>(SecStr::kCoil));
+
     auto dists = buf.leftCols(n - 2).array();
     for (int i = 0; i < n - 4; ++i) {
       // (2, 3, 4) - 0, ..., (n-3, n-2, n-1) - n-5

--- a/src/tools/tm.cpp
+++ b/src/tools/tm.cpp
@@ -55,9 +55,7 @@ namespace internal {
   ArrayXc assign_secstr_approx_full(ConstRef<Matrix3Xd> pts, Matrix3Xd &buf) {
     const int n = static_cast<int>(pts.cols());
 
-    // Classification needs 5-residue windows; for shorter inputs the indexing
-    // below would run out of bounds (e.g. dists.col(n - 4) for n < 4). Return
-    // all-coil - TM-align rejects structures with fewer than 5 residues anyway.
+    // Shorter than the 5-residue window; indexing below would run out of bounds
     if (n < 5)
       return ArrayXc::Constant(n, static_cast<std::int8_t>(SecStr::kCoil));
 

--- a/test/core/geometry_test.cpp
+++ b/test/core/geometry_test.cpp
@@ -405,6 +405,29 @@ TEST(OCTreeTest, NotifyTransformTest) {
   }
 }
 
+TEST(OCTreeTest, NotifyTransformDegenerate) {
+  // Points flat on one axis have zero extent there; notify_transform must not
+  // divide by zero when recovering the per-axis scale.
+  Matrix3Xd m = Matrix3Xd::Random(3, 50);
+  m.row(2).setConstant(5.0);
+  OCTree tree(m);
+
+  Vector3d scale(2.0, 0.5, 3.0);
+  Vector3d trs(1.0, -1.0, 3.0);
+  E::Affine3d x = E::Translation3d(trs) * E::Scaling(scale);
+  m = x * m;
+
+  Vector3d new_max = m.rowwise().maxCoeff(),
+           new_len = new_max - m.rowwise().minCoeff();
+  tree.notify_transform(new_max, new_len);
+
+  for (int i = 0; i < tree.pts().cols(); ++i) {
+    ASSERT_TRUE(tree.pts().col(i).allFinite()) << "i = " << i;
+    NURI_EXPECT_EIGEN_EQ_TOL(tree.pts().col(i), m.col(tree.idxs()[i]), 1e-6)
+        << "i = " << i;
+  }
+}
+
 TEST(OCTreeTest, CoincidentPoints) {
   // More than bucket_size exactly-coincident points must not recurse forever
   // (stack overflow); they collapse into one over-full leaf and every query

--- a/test/core/geometry_test.cpp
+++ b/test/core/geometry_test.cpp
@@ -43,7 +43,7 @@ Vector3d max_of(int octant, const Vector3d &max, const Vector3d &size) {
 void verify_oct_range(int idx, const Matrix3Xd &pts, const OCTree &oct,
                       const Vector3d &max, const Vector3d &size) {
   const auto &node = oct[idx];
-  if (node.nleaf() <= oct.bucket_size()) {
+  if (node.leaf()) {
     const int *ptr = oct.idxs().data() + node.begin();
     for (int i = 0; i < node.nleaf(); ++i) {
       const Vector3d &pt = pts.col(ptr[i]);
@@ -69,7 +69,7 @@ TEST(OCTreeTest, Create) {
   std::vector<int> childs { tree.root() }, idxs;
   for (int i = 0; i < tree.size(); ++i) {
     const auto &node = tree[i];
-    if (node.nleaf() <= tree.bucket_size()) {
+    if (node.leaf()) {
       idxs.insert(idxs.end(), tree.idxs().begin() + node.begin(),
                   tree.idxs().begin() + node.begin() + node.nleaf());
     } else {
@@ -403,6 +403,107 @@ TEST(OCTreeTest, NotifyTransformTest) {
     NURI_EXPECT_EIGEN_EQ_TOL(tree.pts().col(i), m.col(tree.idxs()[i]), 1e-6)
         << "i = " << i;
   }
+}
+
+TEST(OCTreeTest, CoincidentPoints) {
+  // More than bucket_size exactly-coincident points must not recurse forever
+  // (stack overflow); they collapse into one over-full leaf and every query
+  // must still find them all.
+  const int n = 100;
+  const Vector3d p(1.0, 2.0, 3.0);
+  Matrix3Xd m = p.replicate(1, n);
+
+  OCTree tree(m);
+  ASSERT_GT(tree.size(), 0);
+
+  std::vector<int> idxs;
+  std::vector<double> distsq;
+
+  tree.find_neighbors_d(p, 0.5, idxs, distsq);
+  ASSERT_EQ(idxs.size(), n);
+  std::sort(idxs.begin(), idxs.end());
+  for (int i = 0; i < n; ++i)
+    EXPECT_EQ(idxs[i], i) << "i = " << i;
+  for (double d: distsq)
+    EXPECT_DOUBLE_EQ(d, 0.0);
+
+  tree.find_neighbors_kd(p, n, idxs, distsq);
+  EXPECT_EQ(idxs.size(), n);
+
+  std::vector<int> is, js;
+  tree.find_neighbors_self(0.5, is, js);
+  EXPECT_EQ(is.size(), static_cast<size_t>(n) * (n - 1) / 2);
+
+  OCTree other(m);
+  is.clear();
+  js.clear();
+  tree.find_neighbors_tree(other, 0.5, is, js);
+  EXPECT_EQ(is.size(), static_cast<size_t>(n) * n);
+}
+
+TEST(OCTreeTest, CoincidentPointsStructure) {
+  // A cloud mixing scattered points with an over-full coincident cluster has
+  // both internal nodes and a leaf whose nleaf() exceeds bucket_size(). Walking
+  // the tree must classify the latter by leaf(), not by its size.
+  const int nscat = 400, ncoin = 100;
+  Matrix3Xd m(3, nscat + ncoin);
+  m.leftCols(nscat) = Matrix3Xd::Random(3, nscat);
+  m.rightCols(ncoin) = Vector3d(0.25, -0.5, 0.75).replicate(1, ncoin);
+
+  OCTree tree(m);
+  EXPECT_GT(tree.max_nleaf(), tree.bucket_size());
+
+  std::vector<int> childs { tree.root() }, idxs;
+  for (int i = 0; i < tree.size(); ++i) {
+    const auto &node = tree[i];
+    if (node.leaf()) {
+      EXPECT_LE(node.nleaf(), tree.max_nleaf());
+      idxs.insert(idxs.end(), tree.idxs().begin() + node.begin(),
+                  tree.idxs().begin() + node.begin() + node.nleaf());
+    } else {
+      for (int c: node.children())
+        if (c >= 0)
+          childs.push_back(c);
+    }
+  }
+
+  verify_oct_range(tree.root(), m, tree, tree.max(), tree.len());
+
+  ASSERT_EQ(childs.size(), tree.size());
+  std::sort(childs.begin(), childs.end());
+  for (int i = 0; i < childs.size(); ++i)
+    EXPECT_EQ(childs[i], i) << "i = " << i;
+
+  ASSERT_EQ(idxs.size(), m.cols());
+  std::sort(idxs.begin(), idxs.end());
+  for (int i = 0; i < idxs.size(); ++i)
+    EXPECT_EQ(idxs[i], i) << "i = " << i;
+}
+
+TEST(OCTreeTest, EmptyCloud) {
+  Matrix3Xd empty(3, 0);
+  OCTree tree(empty);
+  EXPECT_EQ(tree.size(), 0);
+
+  std::vector<int> idxs;
+  std::vector<double> distsq;
+  tree.find_neighbors_d(Vector3d::Zero(), 1.0, idxs, distsq);
+  EXPECT_TRUE(idxs.empty());
+  tree.find_neighbors_kd(Vector3d::Zero(), 5, idxs, distsq);
+  EXPECT_TRUE(idxs.empty());
+
+  std::vector<int> is, js;
+  tree.find_neighbors_self(1.0, is, js);
+  EXPECT_TRUE(is.empty());
+  OCTree other(empty);
+  tree.find_neighbors_tree(other, 1.0, is, js);
+  EXPECT_TRUE(is.empty());
+
+  // rebuild non-empty then empty again to exercise the reset path
+  tree.rebuild(Matrix3Xd::Random(3, 20));
+  EXPECT_GT(tree.size(), 0);
+  tree.rebuild(empty);
+  EXPECT_EQ(tree.size(), 0);
 }
 
 TEST(VoxelGridTest, Create) {

--- a/test/core/geometry_test.cpp
+++ b/test/core/geometry_test.cpp
@@ -567,6 +567,63 @@ TEST(VoxelGridTest, Create) {
   }
 }
 
+TEST(VoxelGridTest, TooFineCutoff) {
+  Matrix3Xd m = Matrix3Xd::Random(3, 200);
+  const double cutoff = 1e-18;
+
+  VoxelGrid grid(m, cutoff);
+  ASSERT_TRUE((grid.dims() == 1).all());
+  ASSERT_GT(grid.cutoff(), cutoff);
+  EXPECT_EQ(grid.num_cells(), 1);
+
+  MatrixXd dmat = cdist(m, m);
+
+  std::vector<int> idxs;
+  std::vector<double> distsq;
+  for (int q = 0; q < m.cols(); ++q) {
+    grid.find_neighbors_d(m.col(q), idxs, distsq);
+    EXPECT_EQ(idxs.size(), (dmat.row(q).array() <= grid.cutoff()).count())
+        << "q = " << q;
+  }
+
+  std::vector<int> is, js;
+  grid.find_neighbors_self(is, js);
+  EXPECT_EQ(is.size(),
+            ((dmat.array() <= grid.cutoff()).count() - m.cols()) / 2);
+}
+
+TEST(VoxelGridTest, EmptyCloud) {
+  Matrix3Xd empty(3, 0);
+  VoxelGrid grid(empty, 1.0);
+  EXPECT_EQ(grid.pts().cols(), 0);
+
+  std::vector<int> idxs;
+  std::vector<double> distsq;
+  grid.find_neighbors_d(Vector3d::Zero(), idxs, distsq);
+  EXPECT_TRUE(idxs.empty());
+
+  std::vector<int> is, js;
+  grid.find_neighbors_self(is, js);
+  EXPECT_TRUE(is.empty());
+
+  VoxelGrid other(Matrix3Xd::Random(3, 20), 1.0);
+  grid.find_neighbors_grid(other, is, js);
+  EXPECT_TRUE(is.empty());
+  EXPECT_TRUE(grid.find_neighbors_grid(other).empty());
+
+  other.find_neighbors_grid(grid, is, js);
+  EXPECT_TRUE(is.empty());
+
+  // rebuild non-empty then empty again to exercise the reset path
+  grid.rebuild(Matrix3Xd::Random(3, 20));
+  EXPECT_EQ(grid.pts().cols(), 20);
+  grid.rebuild(empty);
+  EXPECT_EQ(grid.pts().cols(), 0);
+
+  grid.find_neighbors_d(Vector3d::Zero(), idxs, distsq);
+  EXPECT_TRUE(idxs.empty());
+}
+
 TEST(VoxelGridTest, FindNeighborByDistance) {
   Matrix3Xd m = Matrix3Xd::Random(3, 500);
   Matrix3Xd test = Matrix3Xd::Random(3, 50);

--- a/test/core/geometry_test.cpp
+++ b/test/core/geometry_test.cpp
@@ -406,8 +406,7 @@ TEST(OCTreeTest, NotifyTransformTest) {
 }
 
 TEST(OCTreeTest, NotifyTransformDegenerate) {
-  // Points flat on one axis have zero extent there; notify_transform must not
-  // divide by zero when recovering the per-axis scale.
+  // Zero extent on one axis: the per-axis scale would divide by zero
   Matrix3Xd m = Matrix3Xd::Random(3, 50);
   m.row(2).setConstant(5.0);
   OCTree tree(m);
@@ -429,9 +428,7 @@ TEST(OCTreeTest, NotifyTransformDegenerate) {
 }
 
 TEST(OCTreeTest, CoincidentPoints) {
-  // More than bucket_size exactly-coincident points must not recurse forever
-  // (stack overflow); they collapse into one over-full leaf and every query
-  // must still find them all.
+  // Over-full coincident cluster: octant splitting can never separate them
   const int n = 100;
   const Vector3d p(1.0, 2.0, 3.0);
   Matrix3Xd m = p.replicate(1, n);
@@ -465,9 +462,7 @@ TEST(OCTreeTest, CoincidentPoints) {
 }
 
 TEST(OCTreeTest, CoincidentPointsStructure) {
-  // A cloud mixing scattered points with an over-full coincident cluster has
-  // both internal nodes and a leaf whose nleaf() exceeds bucket_size(). Walking
-  // the tree must classify the latter by leaf(), not by its size.
+  // Mixed cloud: internal nodes plus a leaf whose nleaf() exceeds bucket_size()
   const int nscat = 400, ncoin = 100;
   Matrix3Xd m(3, nscat + ncoin);
   m.leftCols(nscat) = Matrix3Xd::Random(3, nscat);
@@ -522,7 +517,6 @@ TEST(OCTreeTest, EmptyCloud) {
   tree.find_neighbors_tree(other, 1.0, is, js);
   EXPECT_TRUE(is.empty());
 
-  // rebuild non-empty then empty again to exercise the reset path
   tree.rebuild(Matrix3Xd::Random(3, 20));
   EXPECT_GT(tree.size(), 0);
   tree.rebuild(empty);

--- a/test/tools/galign/galign_test.cpp
+++ b/test/tools/galign/galign_test.cpp
@@ -180,6 +180,42 @@ TEST(GAlign, FlexibleMaxConfClampedToPool) {
   EXPECT_EQ(results.size(), sampling.pool_size + sampling.sample_size);
 }
 
+TEST(GAlign, FlexiblePrunesExcessRigidSeeds) {
+  Molecule mol = read_smiles({ "CCCCCC" });
+
+  Matrix3Xd &conf = mol.confs().emplace_back(3, mol.num_atoms());
+  conf.transpose() << 0.00, 0.0, 0.0,  //
+      1.25, 0.9, 0.0,                  //
+      2.50, 0.0, 0.0,                  //
+      3.75, 0.9, 0.0,                  //
+      5.00, 0.0, 0.0,                  //
+      6.25, 0.9, 0.0;
+
+  GARigidMolInfo info(mol, conf);
+
+  GASamplingArgs sampling;
+  sampling.rigid_min_msd = 0;
+  sampling.rigid_max_conf = 8;
+  sampling.pool_size = 1;
+  sampling.sample_size = 1;
+  sampling.max_gen = 1;
+  sampling.patience = 1;
+
+  GAMinimizeArgs minimize;
+  minimize.max_iters = 1;
+
+  internal::seed_thread(42);
+  std::vector rigid = galign(mol, conf, info, false, sampling.rigid_max_conf,
+                             sampling, minimize);
+  ASSERT_GT(rigid.size(), sampling.pool_size + sampling.sample_size);
+
+  internal::seed_thread(42);
+  std::vector results = galign(mol, conf, info, true, 10, sampling, minimize);
+  ASSERT_EQ(results.size(), sampling.pool_size + sampling.sample_size);
+  for (const GAlignResult &r: results)
+    EXPECT_GE(r.align_score, 0);
+}
+
 TEST(GAlign, CoincidentRotatableBond) {
   Molecule mol = read_smiles({ "CCCC" });
 

--- a/test/tools/galign/galign_test.cpp
+++ b/test/tools/galign/galign_test.cpp
@@ -155,8 +155,7 @@ TEST(GAlign, Flexible) {
 }
 
 TEST(GAlign, FlexibleMaxConfClampedToPool) {
-  // A rotatable bond is required: without one the flexible path
-  // short-circuits to rigid alignment and never builds a pool.
+  // Needs a rotatable bond; otherwise the flexible path never builds a pool
   Molecule mol = read_smiles({ "CCCC" });
 
   Matrix3Xd &conf = mol.confs().emplace_back(3, mol.num_atoms());
@@ -179,6 +178,27 @@ TEST(GAlign, FlexibleMaxConfClampedToPool) {
   internal::seed_thread(42);
   std::vector results = galign(mol, conf, info, true, 10, sampling, minimize);
   EXPECT_EQ(results.size(), sampling.pool_size + sampling.sample_size);
+}
+
+TEST(GAlign, CoincidentRotatableBond) {
+  Molecule mol = read_smiles({ "CCCC" });
+
+  Matrix3Xd &conf = mol.confs().emplace_back(3, mol.num_atoms());
+  conf.transpose() << 0.0, 0.0, 0.0,  //
+      1.5, 0.0, 0.0,                  //
+      2.0, 1.4, 0.0,                  //
+      3.5, 1.4, 0.0;
+
+  const auto nrot = GARigidMolInfo(mol, conf).rot_info().size();
+  ASSERT_GT(nrot, 0);
+
+  // A zero-length axis would turn the rotation into a cos(angle) scaling
+  conf.col(2) = conf.col(1);
+  GARigidMolInfo degen(mol, conf);
+  EXPECT_EQ(degen.rot_info().size(), nrot - 1);
+
+  for (const internal::GARotationInfo &r: degen.rot_info())
+    EXPECT_GT(r.normalizer(), 0);
 }
 }  // namespace
 }  // namespace nuri

--- a/test/tools/galign/galign_test.cpp
+++ b/test/tools/galign/galign_test.cpp
@@ -153,5 +153,32 @@ TEST(GAlign, Flexible) {
   NURI_EXPECT_EIGEN_EQ_TOL(random.matrix(), result.xform.matrix(), 1e-6);
   EXPECT_GE(result.align_score, 0.95);
 }
+
+TEST(GAlign, FlexibleMaxConfClampedToPool) {
+  // A rotatable bond is required: without one the flexible path
+  // short-circuits to rigid alignment and never builds a pool.
+  Molecule mol = read_smiles({ "CCCC" });
+
+  Matrix3Xd &conf = mol.confs().emplace_back(3, mol.num_atoms());
+  conf.transpose() << 0.0, 0.0, 0.0,  //
+      1.5, 0.0, 0.0,                  //
+      2.0, 1.4, 0.0,                  //
+      3.5, 1.4, 0.0;
+
+  GARigidMolInfo info(mol, conf);
+
+  GASamplingArgs sampling;
+  sampling.pool_size = 1;
+  sampling.sample_size = 1;
+  sampling.max_gen = 1;
+  sampling.patience = 1;
+
+  GAMinimizeArgs minimize;
+  minimize.max_iters = 1;
+
+  internal::seed_thread(42);
+  std::vector results = galign(mol, conf, info, true, 10, sampling, minimize);
+  EXPECT_EQ(results.size(), sampling.pool_size + sampling.sample_size);
+}
 }  // namespace
 }  // namespace nuri

--- a/test/tools/tm_test.cpp
+++ b/test/tools/tm_test.cpp
@@ -314,8 +314,6 @@ TEST(TMAlignComponentTest, AssignSecStr) {
 }
 
 TEST(TMAlignComponentTest, AssignSecStrShort) {
-  // Fewer than 5 residues cannot be classified; the assignment must return
-  // all-coil instead of indexing out of bounds.
   const auto coil = static_cast<std::int8_t>(SecStr::kCoil);
   Matrix3Xd buf(3, 8);
   for (int n = 0; n <= 4; ++n) {

--- a/test/tools/tm_test.cpp
+++ b/test/tools/tm_test.cpp
@@ -313,6 +313,20 @@ TEST(TMAlignComponentTest, AssignSecStr) {
   EXPECT_EQ(ss_str, "CCEEEECTHHCCEECCECCC");
 }
 
+TEST(TMAlignComponentTest, AssignSecStrShort) {
+  // Fewer than 5 residues cannot be classified; the assignment must return
+  // all-coil instead of indexing out of bounds.
+  const auto coil = static_cast<std::int8_t>(SecStr::kCoil);
+  Matrix3Xd buf(3, 8);
+  for (int n = 0; n <= 4; ++n) {
+    Matrix3Xd x = Matrix3Xd::Random(3, n);
+    ArrayXc ss = assign_secstr_approx_full(x, buf);
+    ASSERT_EQ(ss.size(), n);
+    for (int i = 0; i < n; ++i)
+      EXPECT_EQ(ss[i], coil) << "n = " << n << ", i = " << i;
+  }
+}
+
 class TMAlignTestBase: public ::testing::Test {
 public:
   constexpr static int lx = 19, ly = 20, l_min = 19, l_max = 20;


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [x] Have you built the project locally without any warnings and errors?
- [x] Do all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [x] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #...

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches widely used Python APIs and spatial indexes; behavior changes (stricter validation, voxel cutoff errors, reader rejection of bad coords) may break callers that relied on silent widening or non-finite data, though that is intentional hardening.
> 
> **Overview**
> Introduces shared Python binding helpers (`check_finite`, `check_interval`, `check_positive`/`check_nonneg`) and routes geometry, algo, tools, CIF, and molecule APIs through them so bad parameters raise consistent `ValueError` messages instead of ad hoc checks. **NumPy arrays** used in bindings now reject NaN/Inf on cast; **molecule conformers** and **format readers** treat non-finite coordinates as errors.
> 
> **VoxelGrid** Python construction/rebuild builds a temporary grid and errors if the cutoff would be silently widened for an overly fine voxel grid; C++ docs warn about cutoff UB. **Octree** gains explicit leaf marking, `max_nleaf` for buffer sizing, empty-cloud early exits, coincident-point handling, and safer `notify_transform` when an axis has zero extent.
> 
> **GAlign** validates sampling parameters even in rigid mode, renames `rigid_min_msd` → `rigid_min_rmsd` (default 3.0), prunes excess rigid seeds before flexible GA, and skips rotatable bonds with coincident endpoints. Smaller fixes: `argpartition` no-ops on invalid `count`, substructure `pop` on empty container, TM-align score args and short secondary-structure sequences, CIF column `width` bounded to 1–80.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65621938c11e1a50c2cd331b96c8b91746d1af9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->