### PR TITLE
feat(fmt): allow empty molecules

### DIFF
--- a/fuzz/fmt/cif_fuzz.cpp
+++ b/fuzz/fmt/cif_fuzz.cpp
@@ -31,9 +31,9 @@ NURI_FUZZ_MAIN(data, size) {
       break;
 
     out.clear();
-    nuri::write_cif_block(out, block, false);
+    nuri::write_cif_block(out, *block, false);
     out.clear();
-    nuri::write_cif_block(out, block, true);
+    nuri::write_cif_block(out, *block, true);
   }
 
   return 0;

--- a/fuzz/fmt/cif_fuzz.cpp
+++ b/fuzz/fmt/cif_fuzz.cpp
@@ -12,6 +12,7 @@
 
 #include "fuzz_utils.h"
 #include "nuri/fmt/cif.h"
+#include "nuri/fmt/parse_result.h"
 
 NURI_FUZZ_MAIN(data, size) {
   static absl::once_flag flag;

--- a/fuzz/fmt/mol2_fuzz.cpp
+++ b/fuzz/fmt/mol2_fuzz.cpp
@@ -4,6 +4,7 @@
 //
 
 #include <sstream>
+#include <utility>
 #include <vector>
 
 #include <absl/base/call_once.h>
@@ -14,6 +15,7 @@
 #include "fuzz_utils.h"
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/mol2.h"
+#include "nuri/fmt/parse_result.h"
 
 NURI_FUZZ_MAIN(data, size) {
   static absl::once_flag flag;
@@ -29,9 +31,11 @@ NURI_FUZZ_MAIN(data, size) {
   std::vector<std::string> block;
   std::string mol2;
   while (reader.getnext(block)) {
-    nuri::Molecule mol = reader.parse(block);
-    if (mol.empty())
+    nuri::ParseResult<nuri::Molecule> res = reader.parse(block);
+    if (!res)
       continue;
+
+    nuri::Molecule mol = *std::move(res);
 
     nuri::write_mol2(mol2, mol);
     mol.confs().clear();

--- a/fuzz/fmt/pdb_fuzz.cpp
+++ b/fuzz/fmt/pdb_fuzz.cpp
@@ -4,6 +4,7 @@
 //
 
 #include <sstream>
+#include <utility>
 #include <vector>
 
 #include <absl/base/call_once.h>
@@ -13,6 +14,7 @@
 
 #include "fuzz_utils.h"
 #include "nuri/core/molecule.h"
+#include "nuri/fmt/parse_result.h"
 #include "nuri/fmt/pdb.h"
 
 NURI_FUZZ_MAIN(data, size) {
@@ -28,7 +30,11 @@ NURI_FUZZ_MAIN(data, size) {
 
   std::vector<std::string> block;
   while (reader.getnext(block)) {
-    nuri::Molecule mol = reader.parse(block);
+    nuri::ParseResult<nuri::Molecule> res = reader.parse(block);
+    if (!res)
+      continue;
+
+    nuri::Molecule mol = *std::move(res);
 
     std::string buf;
     nuri::write_pdb(buf, mol);

--- a/fuzz/fmt/sdf_fuzz.cpp
+++ b/fuzz/fmt/sdf_fuzz.cpp
@@ -6,6 +6,7 @@
 #include <new>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 #include <absl/base/call_once.h>
@@ -15,6 +16,7 @@
 
 #include "fuzz_utils.h"
 #include "nuri/core/molecule.h"
+#include "nuri/fmt/parse_result.h"
 #include "nuri/fmt/sdf.h"
 
 NURI_FUZZ_MAIN(data, size) {
@@ -31,18 +33,20 @@ NURI_FUZZ_MAIN(data, size) {
   std::vector<std::string> block;
   std::string sdf;
   while (reader.getnext(block)) {
-    nuri::Molecule mol;
+    nuri::ParseResult<nuri::Molecule> res;
 
     try {
-      mol = reader.parse(block);
+      res = reader.parse(block);
     } catch (const std::length_error & /* e */) {
       return -1;
     } catch (const std::bad_alloc & /* e */) {
       return -1;
     }
 
-    if (mol.empty())
+    if (!res)
       continue;
+
+    nuri::Molecule mol = *std::move(res);
 
     nuri::write_sdf(sdf, mol, -1, nuri::SDFVersion::kAutomatic);
     nuri::write_sdf(sdf, mol, -1, nuri::SDFVersion::kV2000);

--- a/fuzz/fmt/smiles_fuzz.cpp
+++ b/fuzz/fmt/smiles_fuzz.cpp
@@ -4,6 +4,7 @@
 //
 
 #include <sstream>
+#include <utility>
 #include <vector>
 
 #include <absl/base/call_once.h>
@@ -13,6 +14,7 @@
 
 #include "fuzz_utils.h"
 #include "nuri/core/molecule.h"
+#include "nuri/fmt/parse_result.h"
 #include "nuri/fmt/smiles.h"
 
 NURI_FUZZ_MAIN(data, size) {
@@ -29,9 +31,11 @@ NURI_FUZZ_MAIN(data, size) {
   std::vector<std::string> block;
   std::string smi;
   while (reader.getnext(block)) {
-    nuri::Molecule mol = reader.parse(block);
-    if (mol.empty())
+    nuri::ParseResult<nuri::Molecule> res = reader.parse(block);
+    if (!res)
       continue;
+
+    nuri::Molecule mol = *std::move(res);
 
     nuri::write_smiles(smi, mol);
   }

--- a/include/nuri/fmt/base.h
+++ b/include/nuri/fmt/base.h
@@ -24,6 +24,7 @@
 
 #include "nuri/core/container/dumb_buffer.h"
 #include "nuri/core/molecule.h"
+#include "nuri/fmt/parse_result.h"
 #include "nuri/utils.h"
 
 namespace nuri {
@@ -51,35 +52,56 @@ public:
       return false;
     }
 
-    mol_ = reader_->parse(block_);
+    res_ = reader_->parse(block_);
     return true;
   }
 
   /**
+   * @brief Test whether the current block was parsed successfully.
+   * @pre Previous call to advance() must return true, otherwise the behavior
+   *      is undefined.
+   */
+  bool ok() const { return static_cast<bool>(res_); }
+
+  /**
+   * @brief Get the reason the current block could not be parsed.
+   * @pre Previous call to advance() must return true and ok() must return
+   *      false, otherwise the behavior is undefined.
+   */
+  std::string_view error_msg() const { return res_.error_msg(); }
+
+  /**
    * @brief Get the current molecule.
    * @return Reference to the current molecule.
-   * @pre Previous call to advance() must return true, otherwise the behavior
-   *      is unspecified.
+   * @pre Previous call to advance() and ok() must return true, otherwise the
+   *      behavior is undefined.
    */
-  Molecule &current() { return mol_; }
+  Molecule &current() { return *res_; }
 
   /**
    * @brief Get the current molecule.
    * @return Const reference to the current molecule.
-   * @pre Previous call to advance() must return true, otherwise the behavior
-   *      is unspecified.
+   * @pre Previous call to advance() and ok() must return true, otherwise the
+   *      behavior is undefined.
    */
-  const Molecule &current() const { return mol_; }
+  const Molecule &current() const { return *res_; }
 
 private:
   Reader *reader_;
   std::vector<std::string> block_;
-  Molecule mol_;
+  ParseResult<Molecule> res_;
 };
 
+/**
+ * @brief Read the next molecule from the stream.
+ * @note \p mol is left unchanged if the stream is at the end or the next block
+ *       could not be parsed. This operator cannot report the reason; use
+ *       MoleculeStream::advance() with MoleculeStream::ok() to distinguish the
+ *       two and to obtain the failure reason.
+ */
 template <class Stream>
 Stream &operator>>(Stream &stream, Molecule &mol) {
-  if (stream.advance()) {
+  if (stream.advance() && stream.ok()) {
     mol = std::move(stream.current());
   }
   return stream;
@@ -125,10 +147,12 @@ public:
   /**
    * @brief Parse the current block and return the molecule.
    * @param block The block to parse.
-   * @return The current molecule.
-   * @note The returned molecule will be empty if the block is empty.
+   * @return The current molecule, or the reason it could not be parsed.
+   * @note This never returns a result in the end-of-input state; use getnext()
+   *       to detect the end of the stream.
    */
-  virtual Molecule parse(const std::vector<std::string> &block) const = 0;
+  virtual ParseResult<Molecule>
+  parse(const std::vector<std::string> &block) const = 0;
 
   /**
    * @brief Test whether the reader implementation can provide valid bond
@@ -148,7 +172,8 @@ public:
   DefaultReaderImpl() = default;
   DefaultReaderImpl(std::istream &is): is_(&is) { }
 
-  Molecule parse(const std::vector<std::string> &block) const final {
+  ParseResult<Molecule>
+  parse(const std::vector<std::string> &block) const final {
     return parser(block);
   }
 
@@ -281,10 +306,9 @@ public:
   /**
    * @brief Parse the current block and return the molecule.
    * @param block The block to parse.
-   * @return The current molecule.
-   * @note The returned molecule will be empty if the block is empty.
+   * @return The current molecule, or the reason it could not be parsed.
    */
-  Molecule parse(const std::vector<std::string> &block) const {
+  ParseResult<Molecule> parse(const std::vector<std::string> &block) const {
     return reader_->parse(block);
   }
 
@@ -350,10 +374,9 @@ public:
   /**
    * @brief Parse the current block and return the molecule.
    * @param block The block to parse.
-   * @return The current molecule.
-   * @note The returned molecule will be empty if the block is empty.
+   * @return The current molecule, or the reason it could not be parsed.
    */
-  Molecule parse(const std::vector<std::string> &block) const {
+  ParseResult<Molecule> parse(const std::vector<std::string> &block) const {
     return reader_->parse(block);
   }
 

--- a/include/nuri/fmt/cif.h
+++ b/include/nuri/fmt/cif.h
@@ -27,6 +27,7 @@
 #include <boost/range/iterator_range.hpp>
 //! @endcond
 
+#include "nuri/fmt/parse_result.h"
 #include "nuri/utils.h"
 
 namespace nuri {
@@ -332,29 +333,14 @@ namespace internal {
   class CifBlock {
   public:
     enum class Type : int {
-      kEOF = static_cast<int>(CifToken::kEOF),        // sentinel, end of file
-      kError = static_cast<int>(CifToken::kError),    // sentinel, error state
       kGlobal = static_cast<int>(CifToken::kGlobal),  // global_
       kData = static_cast<int>(CifToken::kData),      // data_[<name>]
     };
 
     CifBlock(CifFrame &&frame, std::vector<CifFrame> &&save, Type type) noexcept
-        : frame_(std::move(frame)), save_(std::move(save)), type_(type) {
-      ABSL_DCHECK(*this);
-    }
+        : frame_(std::move(frame)), save_(std::move(save)), type_(type) { }
 
-    static CifBlock eof() noexcept { return {}; }
-
-    static CifBlock error(std::string_view reason) { return { reason }; }
-    std::string_view error_msg() const {
-      ABSL_DCHECK(type_ == Type::kError);
-      return frame_.name();
-    }
-
-    std::string_view name() const {
-      ABSL_DCHECK(type_ != Type::kError);
-      return frame_.name();
-    }
+    std::string_view name() const { return frame_.name(); }
 
     const CifFrame &data() const { return frame_; }
 
@@ -364,16 +350,7 @@ namespace internal {
 
     std::string validate(bool recursive = true) const;
 
-    constexpr operator bool() const {
-      return type_ != Type::kEOF && type_ != Type::kError;
-    }
-
   private:
-    CifBlock() noexcept: type_(Type::kEOF) { }
-
-    CifBlock(std::string_view error_msg)
-        : frame_({}, std::string { error_msg }), type_(Type::kError) { }
-
     CifFrame frame_;
     std::vector<CifFrame> save_;
     Type type_;
@@ -387,16 +364,16 @@ public:
   /**
    * @brief Parse the next block in the CIF file.
    */
-  internal::CifBlock next();
+  ParseResult<internal::CifBlock> next();
 
   //! @private
-  internal::CifBlock error(std::string_view reason);
+  ParseResult<internal::CifBlock> error(std::string_view reason);
 
 private:
   internal::CifLexer lexer_;
 
-  std::string name_;
-  internal::CifBlock::Type block_ = internal::CifBlock::Type::kEOF;
+  std::string buf_;
+  internal::CifToken block_ = internal::CifToken::kEOF;
 };
 
 /**
@@ -546,11 +523,9 @@ write_cif_frame(std::string &out, const internal::CifFrame &frame,
  *
  * @param out the buffer to append to. On error, it is overwritten with the
  *        error message.
- * @param block the block to serialize. EOF and error blocks cannot be
- *        serialized.
+ * @param block the block to serialize.
  * @param align if true, pad columns/keys for readability.
- * @return true on success; false if the block is EOF/error or any value could
- *         not be serialized.
+ * @return true on success; false if any value could not be serialized.
  */
 extern bool write_cif_block(std::string &out, const internal::CifBlock &block,
                             bool align = false);
@@ -567,9 +542,9 @@ namespace internal {
   parse_data(CifGlobalCtx ctx, std::vector<CifTable> &tables, CifLexer &lexer,
              std::string_view name);
 
-  extern CifBlock next_block(CifParser &parser, CifLexer &lexer,
-                             std::string &next_name,
-                             internal::CifBlock::Type &next_block);
+  extern ParseResult<CifBlock> next_block(CifParser &parser, CifLexer &lexer,
+                                          std::string &next_name,
+                                          CifToken &next_block);
 }  // namespace internal
 }  // namespace nuri
 

--- a/include/nuri/fmt/mmcif.h
+++ b/include/nuri/fmt/mmcif.h
@@ -38,7 +38,7 @@ public:
 
 private:
   CifParser parser_;
-  std::vector<Molecule> mols_;
+  ParseResult<std::vector<Molecule>> res_ = std::vector<Molecule> {};
   int next_ = -1;
 };
 

--- a/include/nuri/fmt/mmcif.h
+++ b/include/nuri/fmt/mmcif.h
@@ -17,11 +17,13 @@
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/base.h"
 #include "nuri/fmt/cif.h"
+#include "nuri/fmt/parse_result.h"
 
 namespace nuri {
-std::vector<Molecule> mmcif_load_frame(const internal::CifFrame &frame);
+ParseResult<std::vector<Molecule>>
+mmcif_load_frame(const internal::CifFrame &frame);
 
-std::vector<Molecule> mmcif_read_next_block(CifParser &parser);
+ParseResult<std::vector<Molecule>> mmcif_read_next_block(CifParser &parser);
 
 class MmcifReader final: public MoleculeReader {
 public:
@@ -29,7 +31,8 @@ public:
 
   bool getnext(std::vector<std::string> &block) override;
 
-  Molecule parse(const std::vector<std::string> &block) const override;
+  ParseResult<Molecule>
+  parse(const std::vector<std::string> &block) const override;
 
   bool bond_valid() const override { return false; }
 

--- a/include/nuri/fmt/mol2.h
+++ b/include/nuri/fmt/mol2.h
@@ -15,15 +15,16 @@
 
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/base.h"
+#include "nuri/fmt/parse_result.h"
 
 namespace nuri {
 /**
  * @brief Read a single Mol2 string and return a molecule.
  *
  * @param mol2 the Mol2 string to read.
- * @return A molecule. On failure, the returned molecule is empty.
+ * @return A molecule, or the reason it could not be parsed.
  */
-extern Molecule read_mol2(const std::vector<std::string> &mol2);
+extern ParseResult<Molecule> read_mol2(const std::vector<std::string> &mol2);
 
 class Mol2Reader final: public DefaultReaderImpl<read_mol2> {
 public:

--- a/include/nuri/fmt/parse_result.h
+++ b/include/nuri/fmt/parse_result.h
@@ -1,0 +1,130 @@
+//
+// Project NuriKit - Copyright 2026 SNU Compbio Lab.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef NURI_FMT_PARSE_RESULT_H_
+#define NURI_FMT_PARSE_RESULT_H_
+
+//! @cond
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include <absl/log/absl_check.h>
+#include <absl/strings/str_cat.h>
+//! @endcond
+
+namespace nuri {
+/**
+ * @brief The state of a ParseResult.
+ */
+enum class ParseStatus : int {
+  kEOF = 0,
+  kValid = 1,
+  kError = 2,
+};
+
+/**
+ * @brief The result of a parse operation, either a value, an error message, or
+ *        a clean end-of-input marker.
+ *
+ * @tparam T The parsed value type. Must not be std::string.
+ *
+ * @note A ParseResult is only ever move-constructed or move-assigned from
+ *       another ParseResult, so it can never become valueless by exception
+ *       unless T's move constructor throws.
+ */
+template <class T>
+class [[nodiscard]] ParseResult {
+public:
+  static_assert(!std::is_same_v<T, std::string>,
+                "ParseResult<std::string> is ambiguous");
+
+  ParseResult() = default;
+
+  // NOLINTNEXTLINE(*-explicit-conversions)
+  ParseResult(T &&value) noexcept(std::is_nothrow_move_constructible_v<T>)
+      : data_(std::move(value)) { }
+
+  /**
+   * @brief Create a result denoting a clean end of input.
+   * @note Block parsers never return this; only stream-level parsers do.
+   */
+  static ParseResult eof() noexcept { return ParseResult(); }
+
+  /**
+   * @brief Create a result denoting a parse failure.
+   * @param args The reason, concatenated with absl::StrCat(). Must not be
+   *        empty.
+   */
+  template <class... Args>
+  static ParseResult error(const Args &...args) {
+    return ParseResult(absl::StrCat(args...));
+  }
+
+  void reset() noexcept { data_ = std::monostate {}; }
+
+  ParseStatus status() const { return static_cast<ParseStatus>(data_.index()); }
+
+  explicit operator bool() const { return status() == ParseStatus::kValid; }
+
+  /**
+   * @brief Get the parsed value.
+   * @pre status() == ParseStatus::kValid.
+   */
+  T &operator*() & {
+    ABSL_DCHECK(status() == ParseStatus::kValid);
+    return *std::get_if<T>(&data_);
+  }
+
+  //! @copydoc operator*()
+  const T &operator*() const & {
+    ABSL_DCHECK(status() == ParseStatus::kValid);
+    return *std::get_if<T>(&data_);
+  }
+
+  //! @copydoc operator*()
+  T &&operator*() && {
+    ABSL_DCHECK(status() == ParseStatus::kValid);
+    return std::move(*std::get_if<T>(&data_));
+  }
+
+  //! @copydoc operator*()
+  T *operator->() { return &**this; }
+
+  //! @copydoc operator*()
+  const T *operator->() const { return &**this; }
+
+  /**
+   * @brief Get the failure reason.
+   * @pre status() == ParseStatus::kError.
+   */
+  std::string_view error_msg() const {
+    ABSL_DCHECK(status() == ParseStatus::kError);
+    return *std::get_if<std::string>(&data_);
+  }
+
+private:
+  explicit ParseResult(std::string &&err): data_(std::move(err)) {
+    ABSL_DCHECK(!std::get_if<std::string>(&data_)->empty());
+  }
+
+  std::variant<std::monostate, T, std::string> data_;
+
+  template <ParseStatus S, class U>
+  constexpr static bool kAlternativeIs = std::is_same_v<
+      std::variant_alternative_t<static_cast<std::size_t>(S), decltype(data_)>,
+      U>;
+
+  static_assert(kAlternativeIs<ParseStatus::kEOF, std::monostate>
+                    && kAlternativeIs<ParseStatus::kValid, T>
+                    && kAlternativeIs<ParseStatus::kError, std::string>,
+                "ParseStatus values must match data_'s alternative indices");
+};
+}  // namespace nuri
+
+#endif /* NURI_FMT_PARSE_RESULT_H_ */

--- a/include/nuri/fmt/pdb.h
+++ b/include/nuri/fmt/pdb.h
@@ -20,6 +20,7 @@
 #include "nuri/core/element.h"
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/base.h"
+#include "nuri/fmt/parse_result.h"
 #include "nuri/utils.h"
 
 namespace nuri {
@@ -27,9 +28,9 @@ namespace nuri {
  * @brief Read a single PDB string and return a molecule.
  *
  * @param pdb the PDB string to read.
- * @return A molecule. On failure, the returned molecule is empty.
+ * @return A molecule, or the reason it could not be parsed.
  */
-extern Molecule read_pdb(const std::vector<std::string> &pdb);
+extern ParseResult<Molecule> read_pdb(const std::vector<std::string> &pdb);
 
 class PDBReader final: public DefaultReaderImpl<read_pdb> {
 public:
@@ -194,7 +195,8 @@ private:
   internal::PropertyMap props_;
 };
 
-extern PDBModel read_pdb_model(const std::vector<std::string> &pdb);
+extern ParseResult<PDBModel>
+read_pdb_model(const std::vector<std::string> &pdb);
 }  // namespace nuri
 
 #endif /* NURI_FMT_PDB_H_ */

--- a/include/nuri/fmt/sdf.h
+++ b/include/nuri/fmt/sdf.h
@@ -15,15 +15,16 @@
 
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/base.h"
+#include "nuri/fmt/parse_result.h"
 
 namespace nuri {
 /**
  * @brief Read a single sdf string and return a molecule.
  *
  * @param sdf the sdf string to read.
- * @return A molecule. On failure, the returned molecule is empty.
+ * @return A molecule, or the reason it could not be parsed.
  */
-extern Molecule read_sdf(const std::vector<std::string> &sdf);
+extern ParseResult<Molecule> read_sdf(const std::vector<std::string> &sdf);
 
 class SDFReader final: public DefaultReaderImpl<read_sdf> {
 public:

--- a/include/nuri/fmt/smiles.h
+++ b/include/nuri/fmt/smiles.h
@@ -15,6 +15,7 @@
 
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/base.h"
+#include "nuri/fmt/parse_result.h"
 
 namespace nuri {
 /**
@@ -23,9 +24,10 @@ namespace nuri {
  * @param smi_block the SMILES block to read. Only the first string is used;
  *                  the rest are ignored. This is to support the interface
  *                  of the reader.
- * @return A molecule. On failure, the returned molecule is empty.
+ * @return A molecule, or the reason it could not be parsed.
  */
-extern Molecule read_smiles(const std::vector<std::string> &smi_block);
+extern ParseResult<Molecule>
+read_smiles(const std::vector<std::string> &smi_block);
 
 class SmilesReader final: public DefaultReaderImpl<read_smiles> {
 public:

--- a/python/src/nuri/fmt/cif.cpp
+++ b/python/src/nuri/fmt/cif.cpp
@@ -311,13 +311,7 @@ private:
 
 class PyCifBlock {
 public:
-  PyCifBlock(internal::CifBlock &&block): block_(std::move(block)) {
-    if (block_.type() == internal::CifBlock::Type::kEOF)
-      throw py::stop_iteration();
-
-    if (block_.type() == internal::CifBlock::Type::kError)
-      throw py::value_error(std::string(block_.error_msg()));
-  }
+  PyCifBlock(internal::CifBlock &&block): block_(std::move(block)) { }
 
   const internal::CifBlock &block() const { return block_; }
 
@@ -379,7 +373,19 @@ public:
     return py::cast(std::make_unique<PyCifParser>(std::move(ifs)));
   }
 
-  PyCifBlock next() { return PyCifBlock(parser_.next()); }
+  PyCifBlock next() {
+    ParseResult<internal::CifBlock> res = parser_.next();
+    switch (res.status()) {
+    case ParseStatus::kEOF:
+      throw py::stop_iteration();
+    case ParseStatus::kError:
+      throw py::value_error(std::string(res.error_msg()));
+    case ParseStatus::kValid:
+      break;
+    }
+
+    return PyCifBlock(*std::move(res));
+  }
 
 private:
   std::ifstream ifs_;

--- a/python/src/nuri/fmt/cif.cpp
+++ b/python/src/nuri/fmt/cif.cpp
@@ -30,6 +30,7 @@
 #include "fmt_internal.h"
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/mmcif.h"
+#include "nuri/fmt/parse_result.h"
 #include "nuri/python/core/core_module.h"
 #include "nuri/python/exception.h"
 #include "nuri/python/typing.h"
@@ -486,7 +487,11 @@ cif_ddl2_frame_as_dict(const PyCifFrame &frame) {
 }
 
 pyt::List<PyMol> mmcif_load_cif_frame(const PyCifFrame &frame) {
-  std::vector<Molecule> mols = mmcif_load_frame(*frame);
+  ParseResult<std::vector<Molecule>> res = mmcif_load_frame(*frame);
+  if (!res)
+    throw py::value_error(std::string(res.error_msg()));
+
+  std::vector<Molecule> mols = *std::move(res);
 
   pyt::List<PyMol> pymols(mols.size());
   for (int i = 0; i < mols.size(); ++i)

--- a/python/src/nuri/fmt/fmt_module.cpp
+++ b/python/src/nuri/fmt/fmt_module.cpp
@@ -17,8 +17,6 @@
 #include <absl/algorithm/container.h>
 #include <absl/log/absl_log.h>
 #include <absl/strings/str_cat.h>
-#include <absl/strings/str_join.h>
-#include <absl/types/span.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/stl/filesystem.h>
@@ -29,6 +27,7 @@
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/base.h"
 #include "nuri/fmt/mol2.h"
+#include "nuri/fmt/parse_result.h"
 #include "nuri/fmt/pdb.h"
 #include "nuri/fmt/sdf.h"
 #include "nuri/fmt/smiles.h"
@@ -70,22 +69,14 @@ public:
       if (!reader_->getnext(block_))
         break;
 
-      Molecule mol = reader_->parse(block_);
-      if (mol.empty()) {
-        std::string text;
-        if (block_.empty()) {
-          absl::StrAppend(&text, "Empty block for molecule.");
-        } else {
-          absl::StrAppend(&text,
-                          "Failed to parse molecule or an empty molecule "
-                          "supplied. The first lines of block are: \n\n  ",
-                          absl::StrJoin(absl::MakeSpan(block_).subspan(0, 5),
-                                        "\n  "));
-        }
-        log_or_throw(text.c_str());
+      ParseResult<Molecule> res = reader_->parse(block_);
+      if (!res) {
+        log_or_throw(
+            absl::StrCat("Failed to parse molecule: ", res.error_msg()).c_str());
         continue;
       }
 
+      Molecule mol = *std::move(res);
       if (!all_confs_finite(mol)) {
         log_or_throw("Molecule has non-finite (NaN or infinite) coordinates.");
         continue;

--- a/python/src/nuri/fmt/pdb.cpp
+++ b/python/src/nuri/fmt/pdb.cpp
@@ -24,6 +24,7 @@
 #include <pybind11/typing.h>
 
 #include "fmt_internal.h"
+#include "nuri/fmt/parse_result.h"
 #include "nuri/python/exception.h"
 #include "nuri/python/typing.h"
 #include "nuri/python/utils.h"
@@ -97,17 +98,17 @@ pyt::List<PDBModel> read_pdb_models(std::istream &is, bool skip_on_error) {
   pyt::List<PDBModel> models;
   std::vector<std::string> block;
   while (reader.getnext(block)) {
-    PDBModel model = read_pdb_model(block);
+    ParseResult<PDBModel> model = read_pdb_model(block);
 
-    if (model.atoms().empty()) {
+    if (!model) {
       if (skip_on_error)
         continue;
 
-      throw py::value_error(
-          absl::StrCat("Failed to read PDB model ", models.size()));
+      throw py::value_error(absl::StrCat(
+          "Failed to read PDB model ", models.size(), ": ", model.error_msg()));
     }
 
-    models.append(std::move(model));
+    models.append(*std::move(model));
   }
 
   return models;

--- a/python/test/fmt/common_test.py
+++ b/python/test/fmt/common_test.py
@@ -38,3 +38,35 @@ def test_reader_options():
 
     mols = list(nuri.readstring("smi", "error", skip_on_error=True))
     assert len(mols) == 0
+
+
+def test_reader_error_reason():
+    with pytest.raises(ValueError, match=r"Failed to parse molecule: .*error"):
+        list(nuri.readstring("smi", "error"))
+
+
+def test_atomless_molecule():
+    # OpenSMILES: a blank line, or one starting with whitespace, is ignored,
+    # so an atom-less molecule is not representable in a SMILES file.
+    assert list(nuri.readstring("smi", "\tempty name")) == []
+
+    sdf = "empty\n\n\n  0  0  0     0  0  0  0  0  0999 V2000\nM  END\n$$$$\n"
+    mols = list(nuri.readstring("sdf", sdf))
+    assert len(mols) == 1
+    assert len(mols[0]) == 0
+
+    mols = list(nuri.readstring("mol2", "@<TRIPOS>MOLECULE\nempty\n"))
+    assert len(mols) == 1
+    assert len(mols[0]) == 0
+    assert mols[0].name == "empty"
+
+    mols = list(
+        nuri.readstring(
+            "pdb",
+            "HEADER    TEST CLASSIFICATION                     01-JAN-25   ONLY"
+            + "\n",
+        )
+    )
+    assert len(mols) == 1
+    assert len(mols[0]) == 0
+    assert mols[0].name == "ONLY"

--- a/python/test/fmt/mmcif_test.py
+++ b/python/test/fmt/mmcif_test.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 import nuri
 from nuri.core import Molecule
@@ -64,3 +65,33 @@ def test_load_mmcif_from_frame(test_data: Path):
     frame = next(read_blocks(test_data / "3cye_part.cif")).data
     mols = frame.as_mols()
     _validate_3cye_part(mols)
+
+
+def test_load_mmcif_no_atom_sites(tmp_path: Path):
+    file = tmp_path / "meta.cif"
+    file.write_text("data_meta\n_x.y 1\n")
+
+    frame = next(read_blocks(file)).data
+    assert len(frame.as_mols()) == 0
+
+
+def test_load_mmcif_malformed_row(tmp_path: Path):
+    file = tmp_path / "bad.cif"
+    file.write_text(
+        "data_bad\n"
+        "loop_\n"
+        "_atom_site.id\n"
+        "_atom_site.type_symbol\n"
+        "_atom_site.label_atom_id\n"
+        "_atom_site.label_comp_id\n"
+        "_atom_site.auth_asym_id\n"
+        "_atom_site.auth_seq_id\n"
+        "_atom_site.Cartn_x\n"
+        "_atom_site.Cartn_y\n"
+        "_atom_site.Cartn_z\n"
+        "1 N N ALA A notanumber 1.000 2.000 3.000\n"
+    )
+
+    frame = next(read_blocks(file)).data
+    with pytest.raises(ValueError, match="_atom_site"):
+        frame.as_mols()

--- a/python/test/fmt/pdb_test.py
+++ b/python/test/fmt/pdb_test.py
@@ -220,3 +220,18 @@ def test_pdb_model_asdict(tmp_path: Path):
         "chains": [{"id": chain.id} for chain in model.chains],
         "props": dict(model.props),
     }
+
+
+def test_pdb_atomless_model(tmp_path: Path):
+    file = tmp_path / "empty.pdb"
+    file.write_text(
+        "HEADER    TEST CLASSIFICATION                     01-JAN-25   ONLY\n"
+    )
+
+    models = pdb.read_models(file)
+    assert len(models) == 1
+
+    model = models[0]
+    assert len(model.atoms) == 0
+    assert len(model.residues) == 0
+    assert len(model.chains) == 0

--- a/src/fmt/cif.cpp
+++ b/src/fmt/cif.cpp
@@ -380,10 +380,6 @@ std::string CifFrame::validate(bool recursive) const {
 }
 
 std::string CifBlock::validate(bool recursive) const {
-  // The eof/error sentinels carry no data frame to validate.
-  if (!*this)
-    return "";
-
   if (recursive) {
     std::string err = frame_.validate();
     if (!err.empty())
@@ -408,8 +404,6 @@ std::string CifBlock::validate(bool recursive) const {
 }
 
 namespace {
-using BlockType = CifBlock::Type;
-
 enum class CifParseCtx {
   kNonLoop,
 
@@ -482,10 +476,11 @@ std::pair<std::string_view, CifToken> parse_data(CifGlobalCtx ctx,
   ABSL_UNREACHABLE();
 }
 
-CifBlock next_block(CifParser &parser, CifLexer &lexer, std::string &next_name,
-                    BlockType &next_block) {
+ParseResult<CifBlock> next_block(CifParser &parser, CifLexer &lexer,
+                                 std::string &next_name,
+                                 CifToken &next_block) {
   std::string name = std::move(next_name);
-  BlockType block_type = next_block;
+  auto block_type = static_cast<CifBlock::Type>(next_block);
 
   std::vector<CifTable> tables;
   std::vector<CifFrame> save_frames;
@@ -501,7 +496,7 @@ CifBlock next_block(CifParser &parser, CifLexer &lexer, std::string &next_name,
       if (type == CifToken::kEOF || type == CifToken::kData
           || type == CifToken::kGlobal) {
         next_name = data;
-        next_block = static_cast<BlockType>(type);
+        next_block = type;
         break;
       }
 
@@ -533,7 +528,6 @@ CifBlock next_block(CifParser &parser, CifLexer &lexer, std::string &next_name,
 }
 }  // namespace internal
 
-using internal::BlockType;
 using internal::CifToken;
 
 CifParser::CifParser(std::istream &is): lexer_(is) {
@@ -546,8 +540,8 @@ CifParser::CifParser(std::istream &is): lexer_(is) {
     case CifToken::kError:
     case CifToken::kGlobal:
     case CifToken::kData:
-      name_ = data;
-      block_ = static_cast<BlockType>(type);
+      buf_ = data;
+      block_ = type;
       return;
     default:
       ABSL_LOG(INFO) << "Skipping stray token before data block: " << type;
@@ -556,26 +550,29 @@ CifParser::CifParser(std::istream &is): lexer_(is) {
   }
 }
 
-internal::CifBlock CifParser::next() {
-  if (block_ == BlockType::kEOF)
-    return internal::CifBlock::eof();
+ParseResult<internal::CifBlock> CifParser::next() {
+  if (block_ == CifToken::kEOF)
+    return ParseResult<internal::CifBlock>::eof();
 
-  if (block_ == BlockType::kError)
-    return internal::CifBlock::error(name_);
+  if (block_ == CifToken::kError)
+    return ParseResult<internal::CifBlock>::error(buf_);
 
-  internal::CifBlock block = internal::next_block(*this, lexer_, name_, block_);
+  ParseResult<internal::CifBlock> block =
+      internal::next_block(*this, lexer_, buf_, block_);
+  if (!block)
+    return block;
 
-  std::string err = block.validate();
+  std::string err = block->validate();
   if (!err.empty())
     return error(err);
 
   return block;
 }
 
-internal::CifBlock CifParser::error(std::string_view reason) {
-  name_ = reason;
-  block_ = BlockType::kError;
-  return internal::CifBlock::error(reason);
+ParseResult<internal::CifBlock> CifParser::error(std::string_view reason) {
+  buf_ = reason;
+  block_ = CifToken::kError;
+  return ParseResult<internal::CifBlock>::error(reason);
 }
 
 namespace internal {
@@ -840,20 +837,15 @@ bool write_cif_frame(std::string &out, const CifFrame &frame,
 }
 
 bool write_cif_block(std::string &out, const CifBlock &block, bool align) {
-  // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
   switch (block.type()) {
   case CifBlock::Type::kData:
     if (!write_cif_frame(out, block.data(), CifFrame::Type::kData, align))
       return false;
     break;
-  case CifBlock::Type::kGlobal: {
+  case CifBlock::Type::kGlobal:
     if (!write_cif_frame(out, block.data(), CifFrame::Type::kGlobal, align))
       return false;
     break;
-  }
-  default:
-    out = "cannot serialize an EOF or error CIF block";
-    return false;
   }
 
   for (const CifFrame &save: block.save_frames()) {

--- a/src/fmt/cif.cpp
+++ b/src/fmt/cif.cpp
@@ -28,6 +28,7 @@
 #include <boost/spirit/home/x3.hpp>
 
 #include "nuri/eigen_config.h"
+#include "nuri/fmt/parse_result.h"
 #include "nuri/utils.h"
 
 namespace nuri {
@@ -477,8 +478,7 @@ std::pair<std::string_view, CifToken> parse_data(CifGlobalCtx ctx,
 }
 
 ParseResult<CifBlock> next_block(CifParser &parser, CifLexer &lexer,
-                                 std::string &next_name,
-                                 CifToken &next_block) {
+                                 std::string &next_name, CifToken &next_block) {
   std::string name = std::move(next_name);
   auto block_type = static_cast<CifBlock::Type>(next_block);
 

--- a/src/fmt/mmcif.cpp
+++ b/src/fmt/mmcif.cpp
@@ -738,10 +738,6 @@ mmcif_load_frame(const internal::CifFrame &frame) {
         coords.tables()[0], coords.tables()[1], coords.tables()[2],
         comp_id.table(), atom_id.table(), alt_id.table(), type_symbol.table(),
         occupancy.table(), model_num.table(), fchg.table() });
-  if (nsite == 0) {
-    ABSL_LOG(WARNING) << "No atom site entries found";
-    return std::move(mols);
-  }
 
   std::vector<MmcifModelData> models;
   absl::flat_hash_map<int, int> model_map;
@@ -751,9 +747,8 @@ mmcif_load_frame(const internal::CifFrame &frame) {
     auto info = MmcifAtomInfo::from_row(group_pdb, res_idx, atom_id, alt_id,
                                         occupancy, i);
     if (!info) {
-      ABSL_LOG(WARNING)
-          << "Invalid atom info; ignoring atom with serial number " << id;
-      return std::move(mols);
+      return ParseResult<std::vector<Molecule>>::error(
+          "invalid _atom_site row with serial number ", *id);
     }
 
     const int mid = model_num[i];
@@ -803,7 +798,7 @@ mmcif_load_frame(const internal::CifFrame &frame) {
         .add_prop("model", absl::StrCat(mid));
   }
 
-  return std::move(mols);
+  return ParseResult<std::vector<Molecule>>(std::move(mols));
 }
 
 ParseResult<std::vector<Molecule>> mmcif_read_next_block(CifParser &parser) {
@@ -820,29 +815,61 @@ ParseResult<std::vector<Molecule>> mmcif_read_next_block(CifParser &parser) {
   return mmcif_load_frame(block->data());
 }
 
+namespace {
+constexpr int kReaderDone = -2;
+}
+
 bool MmcifReader::getnext(std::vector<std::string> &block) {
   block.clear();
 
-  if (mols_.empty()) {
-    ParseResult<std::vector<Molecule>> res = mmcif_read_next_block(parser_);
-    if (!res) {
-      ABSL_LOG_IF(ERROR, res.status() == ParseStatus::kError) << res.error_msg();
-      return false;
+  if (next_ == kReaderDone)
+    return false;
+
+  if (res_ && ++next_ < res_->size())
+    return true;
+
+  next_ = -1;
+
+  while (true) {
+    ParseResult<internal::CifBlock> blk = parser_.next();
+    if (!blk) {
+      next_ = kReaderDone;
+
+      if (blk.status() != ParseStatus::kError) {
+        res_.reset();
+        return false;
+      }
+
+      res_ = ParseResult<std::vector<Molecule>>::error(
+          "cannot parse cif block: ", blk.error_msg());
+      return true;
     }
 
-    mols_ = *std::move(res);
-    next_ = -1;
-  }
+    res_ = mmcif_load_frame(blk->data());
+    if (!res_)
+      return true;
 
-  return ++next_ < mols_.size();
+    if (res_->empty()) {
+      ABSL_LOG(INFO) << "No molecules in block " << blk->name() << "; skipping";
+      continue;
+    }
+
+    next_ = 0;
+    return true;
+  }
 }
 
 ParseResult<Molecule>
 MmcifReader::parse(const std::vector<std::string> & /* block */) const {
-  ABSL_DCHECK_GE(next_, 0);
-  ABSL_DCHECK_LT(next_, mols_.size());
+  ABSL_DCHECK(res_.status() != ParseStatus::kEOF);
 
-  return Molecule(mols_[next_]);
+  if (!res_)
+    return ParseResult<Molecule>::error(res_.error_msg());
+
+  ABSL_DCHECK_GE(next_, 0);
+  ABSL_DCHECK_LT(next_, res_->size());
+
+  return Molecule((*res_)[next_]);
 }
 
 const bool MmcifReaderFactory::kRegistered =

--- a/src/fmt/mmcif.cpp
+++ b/src/fmt/mmcif.cpp
@@ -807,13 +807,13 @@ std::vector<Molecule> mmcif_load_frame(const internal::CifFrame &frame) {
 std::vector<Molecule> mmcif_read_next_block(CifParser &parser) {
   auto block = parser.next();
   if (!block) {
-    if (block.type() == internal::CifBlock::Type::kError)
+    if (block.status() == ParseStatus::kError)
       ABSL_LOG(ERROR) << "Cannot parse cif block: " << block.error_msg();
 
     return {};
   }
 
-  return mmcif_load_frame(block.data());
+  return mmcif_load_frame(block->data());
 }
 
 bool MmcifReader::getnext(std::vector<std::string> &block) {

--- a/src/fmt/mmcif.cpp
+++ b/src/fmt/mmcif.cpp
@@ -33,6 +33,7 @@
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/base.h"
 #include "nuri/fmt/cif.h"
+#include "nuri/fmt/parse_result.h"
 #include "nuri/meta.h"
 #include "nuri/utils.h"
 
@@ -699,7 +700,8 @@ private:
 };
 }  // namespace
 
-std::vector<Molecule> mmcif_load_frame(const internal::CifFrame &frame) {
+ParseResult<std::vector<Molecule>>
+mmcif_load_frame(const internal::CifFrame &frame) {
   std::vector<Molecule> mols;
 
   ResidueIndexer res_idx = ResidueIndexer::atom_site(frame);
@@ -738,7 +740,7 @@ std::vector<Molecule> mmcif_load_frame(const internal::CifFrame &frame) {
         occupancy.table(), model_num.table(), fchg.table() });
   if (nsite == 0) {
     ABSL_LOG(WARNING) << "No atom site entries found";
-    return mols;
+    return std::move(mols);
   }
 
   std::vector<MmcifModelData> models;
@@ -751,7 +753,7 @@ std::vector<Molecule> mmcif_load_frame(const internal::CifFrame &frame) {
     if (!info) {
       ABSL_LOG(WARNING)
           << "Invalid atom info; ignoring atom with serial number " << id;
-      return mols;
+      return std::move(mols);
     }
 
     const int mid = model_num[i];
@@ -801,16 +803,18 @@ std::vector<Molecule> mmcif_load_frame(const internal::CifFrame &frame) {
         .add_prop("model", absl::StrCat(mid));
   }
 
-  return mols;
+  return std::move(mols);
 }
 
-std::vector<Molecule> mmcif_read_next_block(CifParser &parser) {
+ParseResult<std::vector<Molecule>> mmcif_read_next_block(CifParser &parser) {
   auto block = parser.next();
   if (!block) {
-    if (block.status() == ParseStatus::kError)
-      ABSL_LOG(ERROR) << "Cannot parse cif block: " << block.error_msg();
+    if (block.status() == ParseStatus::kError) {
+      return ParseResult<std::vector<Molecule>>::error(
+          "cannot parse cif block: ", block.error_msg());
+    }
 
-    return {};
+    return ParseResult<std::vector<Molecule>>::eof();
   }
 
   return mmcif_load_frame(block->data());
@@ -820,19 +824,25 @@ bool MmcifReader::getnext(std::vector<std::string> &block) {
   block.clear();
 
   if (mols_.empty()) {
-    mols_ = mmcif_read_next_block(parser_);
+    ParseResult<std::vector<Molecule>> res = mmcif_read_next_block(parser_);
+    if (!res) {
+      ABSL_LOG_IF(ERROR, res.status() == ParseStatus::kError) << res.error_msg();
+      return false;
+    }
+
+    mols_ = *std::move(res);
     next_ = -1;
   }
 
   return ++next_ < mols_.size();
 }
 
-Molecule
+ParseResult<Molecule>
 MmcifReader::parse(const std::vector<std::string> & /* block */) const {
   ABSL_DCHECK_GE(next_, 0);
   ABSL_DCHECK_LT(next_, mols_.size());
 
-  return mols_[next_];
+  return Molecule(mols_[next_]);
 }
 
 const bool MmcifReaderFactory::kRegistered =

--- a/src/fmt/mol2.cpp
+++ b/src/fmt/mol2.cpp
@@ -39,6 +39,7 @@
 #include "nuri/core/element.h"
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/base.h"
+#include "nuri/fmt/parse_result.h"
 #include "nuri/utils.h"
 
 namespace nuri {
@@ -554,7 +555,7 @@ void fix_guadinium(Molecule &mol, const std::vector<int> &ccat) {
 }
 }  // namespace
 
-Molecule read_mol2(const std::vector<std::string> &mol2) {
+ParseResult<Molecule> read_mol2(const std::vector<std::string> &mol2) {
   Molecule mol;
   std::vector<Vector3d> pos;
   std::vector<int> ccat;
@@ -600,11 +601,8 @@ Molecule read_mol2(const std::vector<std::string> &mol2) {
     }
   }
 
-  if (!success) {
-    ABSL_LOG(ERROR) << "Failed to parse mol2 block";
-    mol.clear();
-    return mol;
-  }
+  if (!success)
+    return ParseResult<Molecule>::error("failed to parse mol2 block");
 
   fix_aromatic_bonds(mol);
 
@@ -639,7 +637,10 @@ Molecule read_mol2(const std::vector<std::string> &mol2) {
     }
   }
 
-  return mol;
+  if (mol.empty())
+    return ParseResult<Molecule>::error("no atom block found");
+
+  return std::move(mol);
 }
 
 namespace {

--- a/src/fmt/mol2.cpp
+++ b/src/fmt/mol2.cpp
@@ -637,9 +637,6 @@ ParseResult<Molecule> read_mol2(const std::vector<std::string> &mol2) {
     }
   }
 
-  if (mol.empty())
-    return ParseResult<Molecule>::error("no atom block found");
-
   return std::move(mol);
 }
 

--- a/src/fmt/pdb.cpp
+++ b/src/fmt/pdb.cpp
@@ -86,22 +86,27 @@ bool pdb_next_nomodel(std::istream &is, std::string &line,
 }
 
 bool pdb_next_model(std::istream &is, std::string &line,
-                    std::vector<std::string> &block) {
-  size_t orig = block.size();
+                    std::vector<std::string> &block, bool in_model) {
+  bool has_model = in_model;
 
   while (std::getline(is, line)) {
-    // Stop if END/ENDMDL/MASTER/CONECT is found
-    // (coordinate section is over)
+    // Stop if END/MASTER/CONECT is found (coordinate section is over)
     if (line.size() >= 3
-        && (fast_startswith(line, "END") || fast_startswith(line, "MAS")
-            || fast_startswith(line, "CON"))) {
+        && (fast_startswith(line, "MAS")      // MASTER
+            || fast_startswith(line, "CON")   // CONECT
+            || (fast_startswith(line, "END")  // END (and not ENDMDL)
+                && !absl::StartsWith(line, "ENDMDL")))) {
       break;
     }
 
+    if (absl::StartsWith(line, "ENDMDL"))
+      return has_model;
+
+    has_model = has_model || absl::StartsWith(line, "MODEL");
     block.push_back(line);
   }
 
-  return block.size() != orig;
+  return has_model;
 }
 }  // namespace
 
@@ -116,7 +121,8 @@ bool PDBReader::getnext(std::vector<std::string> &block) {
   std::string line;
   line.reserve(80);
 
-  if (!has_model_) {
+  const bool first_model = !has_model_;
+  if (first_model) {
     has_model_ = pdb_next_nomodel(*is_, line, header_, rfooter_);
     if (!has_model_) {
       if (header_.empty()) {
@@ -136,7 +142,7 @@ bool PDBReader::getnext(std::vector<std::string> &block) {
     block = header_;
   }
 
-  if (!pdb_next_model(*is_, line, block)) {
+  if (!pdb_next_model(*is_, line, block, first_model)) {
     block.clear();
     return false;
   }

--- a/src/fmt/pdb.cpp
+++ b/src/fmt/pdb.cpp
@@ -2468,9 +2468,8 @@ next_chain_residue(const std::vector<PDBResolvedResidue> &residues) {
   return { 1, '\0', ' ' };
 }
 
-std::vector<PDBResolvedResidue> resolve_residues(const Molecule &mol) {
-  std::vector<PDBResolvedResidue> residues;
-
+bool resolve_residues(const Molecule &mol,
+                      std::vector<PDBResolvedResidue> &residues) {
   std::vector<std::vector<int>> sub_to_atoms = group_atoms(mol);
 
   for (int i = 0; i < mol.substructures().size(); ++i) {
@@ -2479,17 +2478,13 @@ std::vector<PDBResolvedResidue> resolve_residues(const Molecule &mol) {
 
     const auto &sub = mol.substructures()[i];
     PDBResidueId id = generate_rid_sub(sub);
-    if (id.chain_id == '\0') {
-      residues.clear();
-      return residues;
-    }
+    if (id.chain_id == '\0')
+      return false;
 
     std::vector names =
         resolve_atom_names(mol, sub_to_atoms[i + 1], id, sub.name());
-    if (names.empty()) {
-      residues.clear();
-      return residues;
-    }
+    if (names.empty())
+      return false;
 
     residues.push_back(
         { id, sub.name(), std::move(sub_to_atoms[i + 1]), std::move(names) });
@@ -2497,27 +2492,24 @@ std::vector<PDBResolvedResidue> resolve_residues(const Molecule &mol) {
 
   if (!sub_to_atoms[0].empty()) {
     PDBResidueId id = next_chain_residue(residues);
-    if (id.chain_id == '\0') {
-      residues.clear();
-      return residues;
-    }
+    if (id.chain_id == '\0')
+      return false;
 
     std::vector names = resolve_atom_names(mol, sub_to_atoms[0], id, "UNK");
-    if (names.empty()) {
-      residues.clear();
-      return residues;
-    }
+    if (names.empty())
+      return false;
 
     residues.push_back(
         { id, "UNK", std::move(sub_to_atoms[0]), std::move(names) });
   }
 
-  return residues;
+  return true;
 }
 
 bool can_write_coordinates(const Matrix3Xd &pts) {
-  double min = pts.minCoeff(), max = pts.maxCoeff();
-  return min >= -999.999 && max <= 9999.999;
+  bool underflow = (pts.array() < -999.999).any(),
+       overflow = (pts.array() > 9999.999).any();
+  return !underflow && !overflow;
 }
 
 constexpr std::string_view kNonHetResidues[] {
@@ -2567,8 +2559,8 @@ int write_pdb_single_conf(std::string &out, const Molecule &mol,
 }  // namespace
 
 int write_pdb(std::string &out, const Molecule &mol, int model, int conf) {
-  const std::vector residues = resolve_residues(mol);
-  if (residues.empty()) {
+  std::vector<PDBResolvedResidue> residues;
+  if (!resolve_residues(mol, residues)) {
     ABSL_LOG(ERROR) << "Failed to resolve PDB residues";
     return -1;
   }

--- a/src/fmt/pdb.cpp
+++ b/src/fmt/pdb.cpp
@@ -42,6 +42,7 @@
 #include "nuri/core/graph/graph.h"
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/base.h"
+#include "nuri/fmt/parse_result.h"
 #include "nuri/utils.h"
 
 namespace nuri {
@@ -2041,6 +2042,8 @@ void remove_hbonds(MoleculeMutator &mut) {
 }
 
 struct PDBInternals {
+  std::string error;
+
   std::string_view name;
   internal::PropertyMap props;
 
@@ -2056,7 +2059,7 @@ struct PDBInternals {
 PDBInternals read_pdb_internal(Iterator &it, const Iterator end,
                                std::string &buf, int cap_hint) {
   PDBInternals internals {
-    {}, {}, {}, {}, {}, {}, {}, { static_cast<size_t>(cap_hint) + 1 },
+    {}, {}, {}, {}, {}, {}, {}, {}, { static_cast<size_t>(cap_hint) + 1 },
   };
 
   // Order:
@@ -2108,27 +2111,29 @@ PDBInternals read_pdb_internal(Iterator &it, const Iterator end,
     if (it != end)
       line = *it;
 
-    ABSL_LOG(ERROR) << "Invalid coordinate section record: " << line;
-    internals.atoms.clear();
+    internals.error = absl::StrCat("invalid coordinate section record: ", line);
   }
 
   return internals;
 }
 }  // namespace
 
-Molecule read_pdb(const std::vector<std::string> &pdb) {
-  Molecule mol;
+ParseResult<Molecule> read_pdb(const std::vector<std::string> &pdb) {
   if (ABSL_PREDICT_FALSE(pdb.empty()))
-    return mol;
+    return ParseResult<Molecule>::error("empty PDB block");
 
   auto it = pdb.begin();
   const auto end = pdb.end();
   std::string buf;
 
   PDBInternals internals = read_pdb_internal(it, end, buf, last_serial(pdb));
-  if (internals.atoms.empty())
-    return mol;
+  if (!internals.error.empty())
+    return ParseResult<Molecule>::error(internals.error);
 
+  if (internals.atoms.empty())
+    return ParseResult<Molecule>::error("no ATOM/HETATM records found");
+
+  Molecule mol;
   mol.name() = internals.name;
   mol.props() = std::move(internals.props);
 
@@ -2154,7 +2159,7 @@ Molecule read_pdb(const std::vector<std::string> &pdb) {
         return id.ins_code == ' ' ? "" : std::string_view(&id.ins_code, 1);
       });
 
-  return mol;
+  return std::move(mol);
 }
 
 const bool PDBReaderFactory::kRegistered =
@@ -2195,27 +2200,24 @@ PDBModel::PDBModel(std::vector<PDBAtom> &&atoms,
       chains_(std::move(chains)), major_conf_(build_major_conf(atoms_)),
       props_(std::move(props)) { }
 
-PDBModel read_pdb_model(const std::vector<std::string> &pdb) {
-  std::vector<PDBAtom> atoms;
-  std::vector<PDBResidue> residues;
-  std::vector<PDBChain> chains;
-
-  internal::PropertyMap props;
-
-  if (ABSL_PREDICT_FALSE(pdb.empty())) {
-    return { std::move(atoms), std::move(residues), std::move(chains),
-             std::move(props) };
-  }
+ParseResult<PDBModel> read_pdb_model(const std::vector<std::string> &pdb) {
+  if (ABSL_PREDICT_FALSE(pdb.empty()))
+    return ParseResult<PDBModel>::error("empty PDB block");
 
   auto pit = pdb.begin();
   const auto end = pdb.end();
   std::string buf;
 
   PDBInternals internals = read_pdb_internal(pit, end, buf, last_serial(pdb));
-  if (internals.atoms.empty()) {
-    return { std::move(atoms), std::move(residues), std::move(chains),
-             std::move(props) };
-  }
+  if (!internals.error.empty())
+    return ParseResult<PDBModel>::error(internals.error);
+
+  if (internals.atoms.empty())
+    return ParseResult<PDBModel>::error("no ATOM/HETATM records found");
+
+  std::vector<PDBAtom> atoms;
+  std::vector<PDBResidue> residues;
+  std::vector<PDBChain> chains;
 
   atoms.reserve(internals.atoms.size());
   for (const PDBAtomData &pd: internals.atoms)
@@ -2250,8 +2252,8 @@ PDBModel read_pdb_model(const std::vector<std::string> &pdb) {
   for (auto &p: chain_residues)
     chains.push_back(PDBChain(p.first, std::move(p.second)));
 
-  return { std::move(atoms), std::move(residues), std::move(chains),
-           std::move(internals.props) };
+  return PDBModel(std::move(atoms), std::move(residues), std::move(chains),
+                  std::move(internals.props));
 }
 
 namespace {

--- a/src/fmt/pdb.cpp
+++ b/src/fmt/pdb.cpp
@@ -2130,9 +2130,6 @@ ParseResult<Molecule> read_pdb(const std::vector<std::string> &pdb) {
   if (!internals.error.empty())
     return ParseResult<Molecule>::error(internals.error);
 
-  if (internals.atoms.empty())
-    return ParseResult<Molecule>::error("no ATOM/HETATM records found");
-
   Molecule mol;
   mol.name() = internals.name;
   mol.props() = std::move(internals.props);
@@ -2211,9 +2208,6 @@ ParseResult<PDBModel> read_pdb_model(const std::vector<std::string> &pdb) {
   PDBInternals internals = read_pdb_internal(pit, end, buf, last_serial(pdb));
   if (!internals.error.empty())
     return ParseResult<PDBModel>::error(internals.error);
-
-  if (internals.atoms.empty())
-    return ParseResult<PDBModel>::error("no ATOM/HETATM records found");
 
   std::vector<PDBAtom> atoms;
   std::vector<PDBResidue> residues;

--- a/src/fmt/sdf.cpp
+++ b/src/fmt/sdf.cpp
@@ -41,6 +41,7 @@
 #include "nuri/core/element.h"
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/base.h"
+#include "nuri/fmt/parse_result.h"
 #include "nuri/meta.h"
 #include "nuri/utils.h"
 
@@ -907,7 +908,7 @@ bool read_v3000(Molecule &mol, std::vector<Vector3d> &coords,
 }
 }  // namespace
 
-Molecule read_sdf(const std::vector<std::string> &sdf) {
+ParseResult<Molecule> read_sdf(const std::vector<std::string> &sdf) {
   Molecule mol;
   std::vector<Vector3d> coords;
 
@@ -915,30 +916,25 @@ Molecule read_sdf(const std::vector<std::string> &sdf) {
   const auto end = sdf.end();
 
   auto metadata = read_sdf_header(mol, it, end);
-  if (!metadata) {
-    ABSL_LOG(ERROR) << "Failed to read SDF header";
-    mol.clear();
-    return mol;
-  }
+  if (!metadata)
+    return ParseResult<Molecule>::error("failed to read SDF header");
 
-  if (++it >= end) {
-    ABSL_LOG(ERROR) << "No atom block found";
-    mol.clear();
-    return mol;
-  }
+  if (++it >= end)
+    return ParseResult<Molecule>::error("no atom block found");
 
-  bool ok = false;
+  bool ok;
   if (metadata.version() == 2000) {
     ok = read_v2000(mol, coords, metadata, it, end);
   } else if (metadata.version() == 3000) {
     ok = read_v3000(mol, coords, metadata, it, end);
   } else {
-    ABSL_LOG(ERROR) << "Unknown SDF version: " << metadata.version();
+    return ParseResult<Molecule>::error("unknown SDF version: ",
+                                        metadata.version());
   }
 
   if (!ok) {
-    mol.clear();
-    return mol;
+    return ParseResult<Molecule>::error("failed to read V", metadata.version(),
+                                        " body");
   }
 
   ABSL_LOG_IF(WARNING, mol.num_atoms() != metadata.natoms())
@@ -957,7 +953,10 @@ Molecule read_sdf(const std::vector<std::string> &sdf) {
 
   mol.confs().emplace_back(stack(coords));
 
-  return mol;
+  if (mol.empty())
+    return ParseResult<Molecule>::error("no atoms found");
+
+  return std::move(mol);
 }
 
 namespace {

--- a/src/fmt/sdf.cpp
+++ b/src/fmt/sdf.cpp
@@ -953,9 +953,6 @@ ParseResult<Molecule> read_sdf(const std::vector<std::string> &sdf) {
 
   mol.confs().emplace_back(stack(coords));
 
-  if (mol.empty())
-    return ParseResult<Molecule>::error("no atoms found");
-
   return std::move(mol);
 }
 

--- a/src/fmt/smiles.cpp
+++ b/src/fmt/smiles.cpp
@@ -47,7 +47,8 @@ bool SmilesReader::getnext(std::vector<std::string> &block) {
   }
 
   std::string &smiles = block[0];
-  while (std::getline(*is_, smiles) && smiles.empty()) { }
+  while (std::getline(*is_, smiles)
+         && (smiles.empty() || absl::ascii_isspace(smiles[0]))) { }
   return static_cast<bool>(*is_);
 }
 

--- a/src/fmt/smiles.cpp
+++ b/src/fmt/smiles.cpp
@@ -37,6 +37,7 @@
 #include "nuri/core/element.h"
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/base.h"
+#include "nuri/fmt/parse_result.h"
 #include "nuri/utils.h"
 
 namespace nuri {
@@ -710,13 +711,11 @@ void convert_chirality(Molecule &mol, const parser::RingBonds &ring_bonds) {
 }
 }  // namespace
 
-Molecule read_smiles(const std::vector<std::string> &smi_block) {
-  Molecule mol;
-  if (smi_block.empty()) {
-    ABSL_LOG(WARNING) << "Empty SMILES block";
-    return mol;
-  }
+ParseResult<Molecule> read_smiles(const std::vector<std::string> &smi_block) {
+  if (smi_block.empty())
+    return ParseResult<Molecule>::error("empty SMILES block");
 
+  Molecule mol;
   const std::string &smiles = smi_block[0];
 
   // Context variables
@@ -753,11 +752,8 @@ Molecule read_smiles(const std::vector<std::string> &smi_block) {
       success = false;
     }
 
-    if (!success) {
-      ABSL_LOG(ERROR) << "Parsing failed: " << smiles;
-      mutator.clear();
-      return mol;
-    }
+    if (!success)
+      return ParseResult<Molecule>::error("invalid SMILES: ", smiles);
   }
 
   for (int bid: implicit_aromatics) {
@@ -769,11 +765,8 @@ Molecule read_smiles(const std::vector<std::string> &smi_block) {
     }
   }
 
-  if (!update_bond_configuration(mol, bond_geometry_map)) {
-    ABSL_LOG(ERROR) << "Parsing failed: " << smiles;
-    mol.clear();
-    return mol;
-  }
+  if (!update_bond_configuration(mol, bond_geometry_map))
+    return ParseResult<Molecule>::error("invalid SMILES: ", smiles);
 
   auto hit = has_hydrogens.begin();
   for (auto atom: mol) {
@@ -787,11 +780,11 @@ Molecule read_smiles(const std::vector<std::string> &smi_block) {
 
   convert_chirality(mol, ring_bonds);
 
-  while (begin != smiles.end() && std::isspace(*begin) != 0)
+  while (begin != smiles.end() && absl::ascii_isspace(*begin))
     ++begin;
-  mol.name() = std::string_view(&*begin, smiles.end() - begin);
+  mol.name() = std::string_view(smiles).substr(begin - smiles.begin());
 
-  return mol;
+  return ParseResult<Molecule>(std::move(mol));
 }
 
 namespace {

--- a/test/algo/crdgen_test.cpp
+++ b/test/algo/crdgen_test.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include "nuri/eigen_config.h"
+#include "test_utils.h"
 #include "nuri/core/geometry.h"
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/smiles.h"
@@ -22,7 +23,8 @@
 namespace nuri {
 namespace {
 TEST(Crdgen, CHEMBL2228334) {
-  Molecule mol = read_smiles({ "CC(=O)OC1CCCC2COC(=O)C21" });
+  Molecule mol =
+      internal::must_parse(read_smiles({ "CC(=O)OC1CCCC2COC(=O)C21" }));
   ASSERT_TRUE(MoleculeSanitizer(mol).sanitize_all());
 
   Matrix3Xd &conf = mol.confs().emplace_back(3, mol.num_atoms());
@@ -56,7 +58,8 @@ TEST(Crdgen, CHEMBL2228334) {
 }
 
 TEST(Crdgen, CHEMBL2228334Chiral) {
-  Molecule mol = read_smiles({ "CC(=O)O[C@H]1CCC[C@@H]2COC(=O)[C@@H]21" });
+  Molecule mol = internal::must_parse(
+      read_smiles({ "CC(=O)O[C@H]1CCC[C@@H]2COC(=O)[C@@H]21" }));
   ASSERT_TRUE(MoleculeSanitizer(mol).sanitize_all());
 
   Matrix3Xd &conf = mol.confs().emplace_back(3, mol.num_atoms());

--- a/test/algo/guess_test.cpp
+++ b/test/algo/guess_test.cpp
@@ -1058,7 +1058,7 @@ TEST(GuessSelectedMolecules, GH358) {
 
   int i = 0;
   for (; i < smiles_answers.size() && reader.getnext(blk); ++i) {
-    Molecule mol = reader.parse(blk);
+    Molecule mol = internal::must_parse(reader.parse(blk));
     EXPECT_TRUE(internal::guess_update_subs(mol));
 
     std::string smi = NURI_WRITE_ONCE(write_smiles, mol);
@@ -1099,7 +1099,7 @@ TEST(GuessSelectedMolecules, GH367) {
 
   int i = 0;
   for (; i < smiles_answers.size() && reader.getnext(blk); ++i) {
-    Molecule mol = reader.parse(blk);
+    Molecule mol = internal::must_parse(reader.parse(blk));
     EXPECT_TRUE(internal::guess_update_subs(mol));
 
     std::string smi = NURI_WRITE_ONCE(write_smiles, mol);

--- a/test/algo/guess_test.cpp
+++ b/test/algo/guess_test.cpp
@@ -1256,5 +1256,31 @@ TEST(GuessFchargeOnly, ChargedThiophene) {
   for (int i = 1; i < 4; ++i)
     EXPECT_EQ(mol[i].data().formal_charge(), 0);
 }
+
+TEST(GuessAtomlessMolecule, GuessUpdateSubs) {
+  Molecule mol;
+  mol.confs().emplace_back(3, 0);
+  ASSERT_TRUE(mol.is_3d());
+
+  EXPECT_TRUE(internal::guess_update_subs(mol));
+
+  EXPECT_TRUE(mol.empty());
+  EXPECT_EQ(mol.num_bonds(), 0);
+  ASSERT_EQ(mol.confs().size(), 1);
+  EXPECT_EQ(mol.confs()[0].cols(), 0);
+}
+
+TEST(GuessAtomlessMolecule, GuessEverything) {
+  Molecule mol;
+  mol.confs().emplace_back(3, 0);
+
+  {
+    auto mut = mol.mutator();
+    EXPECT_TRUE(guess_everything(mut));
+  }
+
+  EXPECT_TRUE(mol.empty());
+  EXPECT_EQ(mol.num_bonds(), 0);
+}
 }  // namespace
 }  // namespace nuri

--- a/test/core/molecule/molecule_test.cpp
+++ b/test/core/molecule/molecule_test.cpp
@@ -719,6 +719,15 @@ TEST_F(MoleculeTest, Properties) {
   EXPECT_EQ(mol_.bond_begin()->data().get_name(), "test");
 }
 
+TEST(SanitizeTest, AtomlessMolecule) {
+  Molecule mol;
+  EXPECT_TRUE(MoleculeSanitizer(mol).sanitize_all());
+
+  mol.confs().emplace_back(3, 0);
+  ASSERT_TRUE(mol.is_3d());
+  EXPECT_TRUE(MoleculeSanitizer(mol).sanitize_all());
+}
+
 TEST(SanitizeTest, FindRingsTest) {
   Molecule mol;
 

--- a/test/desc/pcharge_test.cpp
+++ b/test/desc/pcharge_test.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 
+#include "test_utils.h"
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/smiles.h"
 
@@ -14,7 +15,7 @@ namespace nuri {
 namespace {
 // From the original Gasteiger paper
 TEST(ChargeGasteiger, Ethane) {
-  Molecule mol = read_smiles({ "CC" });
+  Molecule mol = internal::must_parse(read_smiles({ "CC" }));
   ASSERT_TRUE(MoleculeSanitizer(mol).sanitize_all());
 
   ASSERT_TRUE(assign_charges_gasteiger(mol));
@@ -26,7 +27,7 @@ TEST(ChargeGasteiger, Ethane) {
 }
 
 TEST(ChargeGasteiger, AcetateIon) {
-  Molecule mol = read_smiles({ "CC(=O)[O-]" });
+  Molecule mol = internal::must_parse(read_smiles({ "CC(=O)[O-]" }));
   ASSERT_TRUE(MoleculeSanitizer(mol).sanitize_all());
 
   ASSERT_TRUE(assign_charges_gasteiger(mol));
@@ -36,7 +37,7 @@ TEST(ChargeGasteiger, AcetateIon) {
 }
 
 TEST(ChargeGasteiger, GuanidiniumChloride) {
-  Molecule mol = read_smiles({ "NC(=[NH2+])N.[Cl-]" });
+  Molecule mol = internal::must_parse(read_smiles({ "NC(=[NH2+])N.[Cl-]" }));
   ASSERT_TRUE(MoleculeSanitizer(mol).sanitize_all());
 
   ASSERT_TRUE(assign_charges_gasteiger(mol));

--- a/test/desc/surface_test.cpp
+++ b/test/desc/surface_test.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 
+#include "test_utils.h"
 #include "nuri/core/geometry.h"
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/sdf.h"
@@ -76,7 +77,7 @@ TEST(SRSasaImpl, TwoSpheres) {
 }
 
 TEST(SRSasa, Phenol) {
-  Molecule mol = read_sdf({
+  Molecule mol = internal::must_parse(read_sdf({
       "",
       "     RDKit          3D",
       "",
@@ -108,7 +109,7 @@ TEST(SRSasa, Phenol) {
       "  6 12  1  0",
       "  7 13  1  0",
       "M  END",
-  });
+  }));
   ASSERT_TRUE(MoleculeSanitizer(mol).sanitize_all());
 
   // Values from RDKit

--- a/test/fmt/base_test.cpp
+++ b/test/fmt/base_test.cpp
@@ -113,14 +113,79 @@ public:
     return false;
   }
 
-  Molecule parse(const std::vector<std::string> & /* block */) const override {
-    return {};
+  ParseResult<Molecule>
+  parse(const std::vector<std::string> & /* block */) const override {
+    return Molecule();
   }
 
   bool bond_valid() const override { return true; }
 };
 
 class DummyReaderFactory: public DefaultReaderFactoryImpl<DummyReader> { };
+
+class StubReader: public MoleculeReader {
+public:
+  bool getnext(std::vector<std::string> &block) override {
+    if (next_ >= 3)
+      return false;
+
+    block.assign(1, std::to_string(next_++));
+    return true;
+  }
+
+  ParseResult<Molecule>
+  parse(const std::vector<std::string> &block) const override {
+    if (block[0] == "1")
+      return ParseResult<Molecule>::error("stub failure");
+
+    Molecule mol;
+    mol.name() = block[0];
+    if (block[0] == "2")
+      mol.mutator().add_atom({});
+
+    return ParseResult<Molecule>(std::move(mol));
+  }
+
+  bool bond_valid() const override { return true; }
+
+private:
+  int next_ = 0;
+};
+
+TEST(MoleculeStreamTest, ReportsParseStatus) {
+  StubReader reader;
+  MoleculeStream<> stream = reader.stream();
+
+  ASSERT_TRUE(stream.advance());
+  ASSERT_TRUE(stream.ok());
+  EXPECT_EQ(stream.current().name(), "0");
+  EXPECT_TRUE(stream.current().empty());
+
+  ASSERT_TRUE(stream.advance());
+  EXPECT_FALSE(stream.ok());
+  EXPECT_EQ(stream.error_msg(), "stub failure");
+
+  ASSERT_TRUE(stream.advance());
+  ASSERT_TRUE(stream.ok());
+  EXPECT_EQ(stream.current().num_atoms(), 1);
+
+  EXPECT_FALSE(stream.advance());
+}
+
+TEST(MoleculeStreamTest, ExtractKeepsValueOnFailure) {
+  StubReader reader;
+  MoleculeStream<> stream = reader.stream();
+
+  Molecule mol;
+  stream >> mol;
+  EXPECT_EQ(mol.name(), "0");
+
+  stream >> mol;
+  EXPECT_EQ(mol.name(), "0");
+
+  stream >> mol;
+  EXPECT_EQ(mol.name(), "2");
+}
 
 TEST(ReaderFactoryTest, CanFindFactory) {
   // Direct comparison of typeid fails on macOS x86_64.

--- a/test/fmt/cif_test.cpp
+++ b/test/fmt/cif_test.cpp
@@ -58,6 +58,7 @@
 #include <vector>
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/log/absl_check.h>
 #include <absl/strings/match.h>
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_cat.h>
@@ -504,10 +505,10 @@ TEST(CifParseTest, PDB1A8O) {
   ASSERT_TRUE(ifs) << "Failed to open file: 1a8o.cif";
 
   CifParser parser(ifs);
-  CifBlock block = parser.next();
+  ParseResult<CifBlock> block = parser.next();
   ASSERT_TRUE(block) << "Failed to parse";
 
-  const CifFrame &frame = block.data();
+  const CifFrame &frame = block->data();
   EXPECT_EQ(frame.name(), "1A8O");
   EXPECT_EQ(frame.total_cols(), 574);
 
@@ -677,11 +678,11 @@ TEST(CifParseTest, CCD) {
 
   CifParser parser(ifs);
   for (auto id: ids) {
-    CifBlock block = parser.next();
+    ParseResult<CifBlock> block = parser.next();
     if (!block)
       FAIL() << "Failed to parse block: " << id;
 
-    const CifFrame &frame = block.data();
+    const CifFrame &frame = block->data();
     EXPECT_EQ(frame.name(), id);
 
     {
@@ -692,8 +693,8 @@ TEST(CifParseTest, CCD) {
     }
   }
 
-  CifBlock block = parser.next();
-  EXPECT_TRUE(block.type() == CifBlock::Type::kEOF);
+  ParseResult<CifBlock> block = parser.next();
+  EXPECT_EQ(block.status(), ParseStatus::kEOF);
 }
 
 struct ExpectedData {
@@ -746,15 +747,15 @@ data_publication
   };
 
   for (auto [name, type, cols, saved]: expected) {
-    CifBlock block = parser.next();
+    ParseResult<CifBlock> block = parser.next();
     if (!block)
       FAIL() << "Failed to parse block: " << name;
 
-    const CifFrame &frame = block.data();
+    const CifFrame &frame = block->data();
     EXPECT_EQ(frame.name(), name);
-    EXPECT_EQ(static_cast<int>(block.type()), static_cast<int>(type));
-    EXPECT_EQ(block.data().total_cols(), cols);
-    EXPECT_EQ(block.save_frames().size(), saved);
+    EXPECT_EQ(static_cast<int>(block->type()), static_cast<int>(type));
+    EXPECT_EQ(block->data().total_cols(), cols);
+    EXPECT_EQ(block->save_frames().size(), saved);
   }
 }
 
@@ -767,11 +768,10 @@ data_publication
 )cif");
 
   CifParser parser(data);
-  CifBlock block = parser.next();
+  ParseResult<CifBlock> block = parser.next();
 
   EXPECT_FALSE(block) << "Block should error";
-  EXPECT_EQ(static_cast<int>(block.type()),
-            static_cast<int>(CifBlock::Type::kError));
+  EXPECT_EQ(block.status(), ParseStatus::kError);
   EXPECT_PRED2(str_case_contains, block.error_msg(), "unterminated quote");
 }
 
@@ -1032,7 +1032,11 @@ FrameMap frame_map(const CifFrame &frame) {
 CifBlock reparse(const std::string &cif) {
   std::stringstream ss { cif };
   CifParser parser(ss);
-  return parser.next();
+
+  ParseResult<CifBlock> res = parser.next();
+  ABSL_CHECK(res) << "Failed to re-parse written CIF: " << cif;
+
+  return *std::move(res);
 }
 
 CifTable
@@ -1086,7 +1090,6 @@ TEST_P(CifWriteAlignTest, BuildAndRoundTrip) {
   ASSERT_TRUE(write_cif_block(out, block, align()));
 
   CifBlock back = reparse(out);
-  ASSERT_TRUE(back) << out;
   EXPECT_EQ(back.name(), "test");
   EXPECT_EQ(frame_map(block.data()), frame_map(back.data()));
 }
@@ -1153,8 +1156,6 @@ TEST(CifWriteBlockTest, Align) {
   // reparse both, ensure identical data model
   CifBlock pb = reparse("data_x\n" + plain);
   CifBlock ab = reparse("data_x\n" + aligned);
-  ASSERT_TRUE(pb);
-  ASSERT_TRUE(ab);
   EXPECT_EQ(frame_map(pb.data()), frame_map(ab.data()));
 }
 
@@ -1184,7 +1185,6 @@ TEST_P(CifWriteAlignTest, SaveFrames) {
   ASSERT_TRUE(write_cif_block(out, block, align()));
 
   CifBlock back = reparse(out);
-  ASSERT_TRUE(back) << out;
   ASSERT_EQ(back.save_frames().size(), 1U);
   EXPECT_EQ(back.save_frames()[0].name(), "fragment_1");
   EXPECT_EQ(frame_map(block.save_frames()[0]),
@@ -1196,16 +1196,15 @@ TEST_P(CifWriteAlignTest, PDB1A8ORoundTrip) {
   ASSERT_TRUE(ifs) << "Failed to open file: 1a8o.cif";
 
   CifParser parser(ifs);
-  CifBlock block = parser.next();
+  ParseResult<CifBlock> block = parser.next();
   ASSERT_TRUE(block) << "Failed to parse";
 
   std::string out;
-  ASSERT_TRUE(write_cif_block(out, block, align()));
+  ASSERT_TRUE(write_cif_block(out, *block, align()));
 
   CifBlock back = reparse(out);
-  ASSERT_TRUE(back) << "Failed to re-parse written CIF";
   EXPECT_EQ(back.name(), "1A8O");
-  EXPECT_EQ(frame_map(block.data()), frame_map(back.data()));
+  EXPECT_EQ(frame_map(block->data()), frame_map(back.data()));
 }
 
 TEST_P(CifWriteAlignTest, EmptyTable) {
@@ -1243,7 +1242,6 @@ TEST(CifWriteBlockTest, AlignedTextFieldInLoop) {
   EXPECT_EQ(out, "loop_\n_x\n_y\naaaa z\np\n;c\nd\n;\n");
 
   CifBlock back = reparse("data_x\n" + out);
-  ASSERT_TRUE(back) << out;
   std::vector<CifTable> tv;
   tv.push_back(make_table(
       {
@@ -1418,10 +1416,6 @@ TEST(CifBlockValidateTest, RejectsMalformed) {
   std::string bad_save_err = block(std::move(bad_save)).validate();
   EXPECT_PRED2(str_case_contains, bad_save_err, "duplicate cif key");
   EXPECT_PRED2(str_case_contains, bad_save_err, "in save frame sf");
-
-  // sentinels carry no data frame.
-  EXPECT_EQ(CifBlock::eof().validate(), "");
-  EXPECT_EQ(CifBlock::error("boom").validate(), "");
 }
 
 TEST_P(CifWriteAlignTest, GlobalBlock) {
@@ -1439,20 +1433,10 @@ TEST_P(CifWriteAlignTest, GlobalBlock) {
   EXPECT_TRUE(absl::StartsWith(out, "global_")) << out;
 
   CifBlock back = reparse(out);
-  ASSERT_TRUE(back) << out;
   EXPECT_EQ(back.type(), CifBlock::Type::kGlobal);
   EXPECT_EQ(frame_map(block.data()), frame_map(back.data()));
 }
 
-TEST(CifWriteBlockTest, NonSerializableBlock) {
-  std::string out;
-  EXPECT_FALSE(write_cif_block(out, CifBlock::eof()));
-  EXPECT_PRED2(str_case_contains, out, "cannot serialize");
-
-  out.clear();
-  EXPECT_FALSE(write_cif_block(out, CifBlock::error("boom")));
-  EXPECT_PRED2(str_case_contains, out, "cannot serialize");
-}
 }  // namespace
 }  // namespace internal
 }  // namespace nuri

--- a/test/fmt/mmcif_test.cpp
+++ b/test/fmt/mmcif_test.cpp
@@ -34,7 +34,8 @@ TEST_F(MmcifTest, BasicParsing) {
   set_test_file("1a8o.cif");
 
   CifParser parser(ifs_);
-  std::vector mols = mmcif_read_next_block(parser);
+  std::vector<Molecule> mols =
+      internal::must_parse(mmcif_read_next_block(parser));
   ASSERT_EQ(mols.size(), 1);
 
   const Molecule &mol = mols[0];
@@ -67,7 +68,8 @@ TEST_F(MmcifTest, HandleMultipleModels) {
   set_test_file("3cye_part.cif");
 
   CifParser parser(ifs_);
-  std::vector mols = mmcif_read_next_block(parser);
+  std::vector<Molecule> mols =
+      internal::must_parse(mmcif_read_next_block(parser));
   ASSERT_EQ(mols.size(), 2);
 
   EXPECT_EQ(mols[0].name(), "3CYE");
@@ -115,7 +117,8 @@ protected:
     ASSERT_TRUE(ifs) << "Failed to open file: 1alx.cif";
 
     CifParser parser(ifs);
-    std::vector<Molecule> mols = mmcif_read_next_block(parser);
+    std::vector<Molecule> mols =
+        internal::must_parse(mmcif_read_next_block(parser));
     ASSERT_EQ(mols.size(), 1);
 
     mol_ = std::move(mols[0]);

--- a/test/fmt/mmcif_test.cpp
+++ b/test/fmt/mmcif_test.cpp
@@ -5,6 +5,9 @@
 
 #include "nuri/fmt/mmcif.h"
 
+#include <sstream>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include <boost/iterator/filter_iterator.hpp>
@@ -107,6 +110,177 @@ TEST_F(MmcifTest, HandleMultipleModels) {
   ASSERT_EQ(mols[1].substructures().size(), 6);
   EXPECT_EQ(mols[1].substructures()[0].name(), "VAL");
   EXPECT_EQ(mols[1].substructures()[0].num_atoms(), 7);
+}
+
+constexpr std::string_view kThreeBlocks = R"cif(
+data_first
+loop_
+_atom_site.group_PDB
+_atom_site.id
+_atom_site.type_symbol
+_atom_site.label_atom_id
+_atom_site.label_comp_id
+_atom_site.label_asym_id
+_atom_site.label_seq_id
+_atom_site.Cartn_x
+_atom_site.Cartn_y
+_atom_site.Cartn_z
+ATOM 1 N N ALA A 1 1.000 2.000 3.000
+ATOM 2 C CA ALA A 1 2.000 3.000 4.000
+data_middle
+loop_
+_atom_site.group_PDB
+_atom_site.id
+_atom_site.type_symbol
+_atom_site.label_atom_id
+_atom_site.label_comp_id
+_atom_site.label_asym_id
+_atom_site.label_seq_id
+_atom_site.Cartn_x
+_atom_site.Cartn_y
+_atom_site.Cartn_z
+data_last
+loop_
+_atom_site.group_PDB
+_atom_site.id
+_atom_site.type_symbol
+_atom_site.label_atom_id
+_atom_site.label_comp_id
+_atom_site.label_asym_id
+_atom_site.label_seq_id
+_atom_site.Cartn_x
+_atom_site.Cartn_y
+_atom_site.Cartn_z
+ATOM 1 O O HOH B 1 5.000 6.000 7.000
+)cif";
+
+TEST(MmcifLoadFrameTest, NoAtomSites) {
+  std::istringstream iss("data_meta\n_x.y 1\n");
+  CifParser parser(iss);
+
+  ParseResult<internal::CifBlock> block = parser.next();
+  ASSERT_TRUE(block) << "Failed to parse";
+
+  ParseResult<std::vector<Molecule>> mols = mmcif_load_frame(block->data());
+  ASSERT_TRUE(mols) << mols.error_msg();
+  EXPECT_TRUE(mols->empty());
+}
+
+TEST(MmcifReaderTest, SkipBlocksWithoutAtomSites) {
+  std::istringstream iss(std::string { kThreeBlocks });
+  MmcifReader reader(iss);
+  auto ms = reader.stream();
+
+  ASSERT_TRUE(ms.advance());
+  ASSERT_TRUE(ms.ok()) << ms.error_msg();
+  EXPECT_EQ(ms.current().name(), "first");
+  EXPECT_EQ(ms.current().num_atoms(), 2);
+
+  ASSERT_TRUE(ms.advance());
+  ASSERT_TRUE(ms.ok()) << ms.error_msg();
+  EXPECT_EQ(ms.current().name(), "last");
+  EXPECT_EQ(ms.current().num_atoms(), 1);
+
+  EXPECT_FALSE(ms.advance());
+}
+
+TEST(MmcifReaderTest, ReportMalformedAtomSiteRow) {
+  std::istringstream iss(R"cif(
+data_bad
+loop_
+_atom_site.id
+_atom_site.type_symbol
+_atom_site.label_atom_id
+_atom_site.label_comp_id
+_atom_site.auth_asym_id
+_atom_site.auth_seq_id
+_atom_site.Cartn_x
+_atom_site.Cartn_y
+_atom_site.Cartn_z
+1 N N ALA A notanumber 1.000 2.000 3.000
+)cif");
+
+  MmcifReader reader(iss);
+  auto ms = reader.stream();
+
+  ASSERT_TRUE(ms.advance());
+  EXPECT_FALSE(ms.ok());
+  EXPECT_THAT(ms.error_msg(), testing::HasSubstr("_atom_site"));
+
+  EXPECT_FALSE(ms.advance());
+}
+
+TEST(MmcifReaderTest, ContinuePastMalformedBlock) {
+  std::istringstream iss(R"cif(
+data_first
+loop_
+_atom_site.group_PDB
+_atom_site.id
+_atom_site.type_symbol
+_atom_site.label_atom_id
+_atom_site.label_comp_id
+_atom_site.label_asym_id
+_atom_site.label_seq_id
+_atom_site.Cartn_x
+_atom_site.Cartn_y
+_atom_site.Cartn_z
+ATOM 1 N N ALA A 1 1.000 2.000 3.000
+data_bad
+loop_
+_atom_site.group_PDB
+_atom_site.id
+_atom_site.type_symbol
+_atom_site.label_atom_id
+_atom_site.label_comp_id
+_atom_site.label_asym_id
+_atom_site.label_seq_id
+_atom_site.Cartn_x
+_atom_site.Cartn_y
+_atom_site.Cartn_z
+ATOM 1 N N ALA A notanumber 1.000 2.000 3.000
+data_last
+loop_
+_atom_site.group_PDB
+_atom_site.id
+_atom_site.type_symbol
+_atom_site.label_atom_id
+_atom_site.label_comp_id
+_atom_site.label_asym_id
+_atom_site.label_seq_id
+_atom_site.Cartn_x
+_atom_site.Cartn_y
+_atom_site.Cartn_z
+ATOM 1 O O HOH B 1 5.000 6.000 7.000
+)cif");
+
+  MmcifReader reader(iss);
+  auto ms = reader.stream();
+
+  ASSERT_TRUE(ms.advance());
+  ASSERT_TRUE(ms.ok()) << ms.error_msg();
+  EXPECT_EQ(ms.current().name(), "first");
+
+  ASSERT_TRUE(ms.advance());
+  EXPECT_FALSE(ms.ok());
+  EXPECT_THAT(ms.error_msg(), testing::HasSubstr("_atom_site"));
+
+  ASSERT_TRUE(ms.advance());
+  ASSERT_TRUE(ms.ok()) << ms.error_msg();
+  EXPECT_EQ(ms.current().name(), "last");
+
+  EXPECT_FALSE(ms.advance());
+}
+
+TEST(MmcifReaderTest, ReportCifSyntaxError) {
+  std::istringstream iss("data_bad\n_x.y 'unterminated\n");
+  MmcifReader reader(iss);
+  auto ms = reader.stream();
+
+  ASSERT_TRUE(ms.advance());
+  EXPECT_FALSE(ms.ok());
+  EXPECT_THAT(ms.error_msg(), testing::HasSubstr("cannot parse cif block"));
+
+  EXPECT_FALSE(ms.advance());
 }
 
 class PDB1alxTest: public testing::Test {

--- a/test/fmt/mol2_test.cpp
+++ b/test/fmt/mol2_test.cpp
@@ -61,12 +61,6 @@ NO_CHARGES
 TEST_F(Mol2Test, MalformedParsing) {
   set_test_string(R"mol2(
 @<TRIPOS>MOLECULE
-@<TRIPOS>MOLECULE
-empty error
-@<TRIPOS>MOLECULE
-******
-a b c d
-@<TRIPOS>MOLECULE
 @<TRIPOS>BOND
      1     1     2    1
 @<TRIPOS>MOLECULE
@@ -116,13 +110,6 @@ NO_CHARGES
      1     1     2    1
      2     2     1    1
 @<TRIPOS>MOLECULE
-corina - carboxylic acid
-   4    3    0    0    0
-SMALL
-NO_CHARGES
-
-
-@<TRIPOS>MOLECULE
 *****
  1 0 0 0 0
 SMALL
@@ -160,9 +147,59 @@ GASTEIGER
 charge 1
 )mol2");
 
-  for (int i = 0; i < 12; ++i) {
+  for (int i = 0; i < 8; ++i) {
     NURI_FMT_TEST_PARSE_FAIL();
   }
+}
+
+TEST_F(Mol2Test, ReportMalformedReason) {
+  set_test_string(R"mol2(
+@<TRIPOS>MOLECULE
+*****
+ 1 0 0 0 0
+SMALL
+NO_CHARGES
+
+
+@<TRIPOS>ATOM
+      1 N           0    0.0000    0.0000 N.3
+@<TRIPOS>BOND
+     1     1     2    1
+)mol2");
+
+  NURI_FMT_TEST_PARSE_FAIL_MSG("failed to parse mol2 block");
+}
+
+TEST_F(Mol2Test, EmptyMolecule) {
+  set_test_string(R"mol2(
+@<TRIPOS>MOLECULE
+@<TRIPOS>MOLECULE
+empty error
+@<TRIPOS>MOLECULE
+******
+a b c d
+@<TRIPOS>MOLECULE
+corina - carboxylic acid
+   4    3    0    0    0
+SMALL
+NO_CHARGES
+
+
+@<TRIPOS>MOLECULE
+zero rows
+ 0 0 0 0 0
+SMALL
+NO_CHARGES
+
+
+@<TRIPOS>ATOM
+)mol2");
+
+  NURI_FMT_TEST_NEXT_EMPTY_MOL("");
+  NURI_FMT_TEST_NEXT_EMPTY_MOL("empty error");
+  NURI_FMT_TEST_NEXT_EMPTY_MOL("******");
+  NURI_FMT_TEST_NEXT_EMPTY_MOL("corina - carboxylic acid");
+  NURI_FMT_TEST_NEXT_EMPTY_MOL("zero rows");
 }
 
 /* From here, some molecules are written twice: one for openbabel, the other

--- a/test/fmt/parse_result_test.cpp
+++ b/test/fmt/parse_result_test.cpp
@@ -1,0 +1,71 @@
+//
+// Project NuriKit - Copyright 2026 SNU Compbio Lab.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "nuri/fmt/parse_result.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace nuri {
+namespace {
+using Result = ParseResult<std::vector<int>>;
+
+TEST(ParseResultTest, HoldValue) {
+  Result res = std::vector { 1, 2, 3 };
+
+  EXPECT_EQ(res.status(), ParseStatus::kValid);
+  EXPECT_TRUE(res);
+  EXPECT_EQ(res->size(), 3);
+  EXPECT_EQ((*res)[1], 2);
+
+  (*res)[1] = 20;
+  EXPECT_EQ(res->at(1), 20);
+}
+
+TEST(ParseResultTest, HoldError) {
+  Result res = Result::error("bad input");
+
+  EXPECT_EQ(res.status(), ParseStatus::kError);
+  EXPECT_FALSE(res);
+  EXPECT_EQ(res.error_msg(), "bad input");
+}
+
+TEST(ParseResultTest, HoldEof) {
+  Result res = Result::eof();
+
+  EXPECT_EQ(res.status(), ParseStatus::kEOF);
+  EXPECT_FALSE(res);
+}
+
+TEST(ParseResultTest, FormatError) {
+  Result res = Result::error("cannot parse line ", 42, ": ", "x y z");
+  ASSERT_EQ(res.status(), ParseStatus::kError);
+  EXPECT_EQ(res.error_msg(), "cannot parse line 42: x y z");
+}
+
+TEST(ParseResultTest, Move) {
+  Result res = std::vector { 1, 2, 3 };
+  std::vector<int> moved = *std::move(res);
+  EXPECT_EQ(moved.size(), 3);
+
+  Result other = Result::error("boom");
+  Result moved_res = std::move(other);
+  ASSERT_EQ(moved_res.status(), ParseStatus::kError);
+  EXPECT_EQ(moved_res.error_msg(), "boom");
+
+  moved_res = Result::eof();
+  EXPECT_EQ(moved_res.status(), ParseStatus::kEOF);
+}
+
+TEST(ParseResultTest, ConstAccess) {
+  const Result res = std::vector { 1, 2, 3 };
+  EXPECT_EQ(res->size(), 3);
+  EXPECT_EQ((*res)[0], 1);
+}
+}  // namespace
+}  // namespace nuri

--- a/test/fmt/pdb_test.cpp
+++ b/test/fmt/pdb_test.cpp
@@ -487,6 +487,54 @@ TEST(PDBWriteTest, Molecule2D) {
   EXPECT_EQ(mols[0][0].data().atomic_number(), 6);
 }
 
+TEST(PDBEmptyTest, HeaderOnly) {
+  std::istringstream iss(
+      "HEADER    TEST CLASSIFICATION                     01-JAN-25   ONLY\n");
+  PDBReader reader(iss);
+  auto ms = reader.stream();
+
+  ASSERT_TRUE(ms.advance());
+  ASSERT_TRUE(ms.ok()) << ms.error_msg();
+  EXPECT_EQ(ms.current().name(), "ONLY");
+  EXPECT_TRUE(ms.current().empty());
+  EXPECT_EQ(internal::get_key(ms.current().props(), "classification"),
+            "TEST CLASSIFICATION");
+
+  EXPECT_FALSE(ms.advance());
+}
+
+TEST(PDBEmptyTest, EmptyModelBlock) {
+  std::vector<std::string> block {
+    "HEADER    TEST CLASSIFICATION                     01-JAN-25   ONLY",
+    "MODEL        1", "ENDMDL"
+  };
+
+  ParseResult<Molecule> mol = read_pdb(block);
+  ASSERT_TRUE(mol) << mol.error_msg();
+  EXPECT_EQ(mol->name(), "ONLY");
+  EXPECT_TRUE(mol->empty());
+  EXPECT_EQ(internal::get_key(mol->props(), "model"), "1");
+  ASSERT_EQ(mol->confs().size(), 1);
+  EXPECT_EQ(mol->confs()[0].cols(), 0);
+
+  ParseResult<PDBModel> model = read_pdb_model(block);
+  ASSERT_TRUE(model) << model.error_msg();
+  EXPECT_TRUE(model->atoms().empty());
+  EXPECT_TRUE(model->residues().empty());
+  EXPECT_TRUE(model->chains().empty());
+  EXPECT_EQ(model->major_conf().cols(), 0);
+}
+
+TEST(PDBEmptyTest, EmptyBlockIsError) {
+  ParseResult<Molecule> mol = read_pdb({});
+  ASSERT_FALSE(mol);
+  EXPECT_THAT(mol.error_msg(), testing::HasSubstr("empty PDB block"));
+
+  ParseResult<PDBModel> model = read_pdb_model({});
+  ASSERT_FALSE(model);
+  EXPECT_THAT(model.error_msg(), testing::HasSubstr("empty PDB block"));
+}
+
 TEST(PDBWriteTest, EmptyMolecule) {
   Molecule mol;
   mol.name() = "empty";

--- a/test/fmt/pdb_test.cpp
+++ b/test/fmt/pdb_test.cpp
@@ -487,6 +487,27 @@ TEST(PDBWriteTest, Molecule2D) {
   EXPECT_EQ(mols[0][0].data().atomic_number(), 6);
 }
 
+TEST(PDBWriteTest, EmptyMolecule) {
+  Molecule mol;
+  mol.name() = "empty";
+
+  std::string pdb;
+  EXPECT_GE(write_pdb(pdb, mol), 0);
+  EXPECT_TRUE(pdb.empty()) << pdb;
+
+  ASSERT_FALSE(mol.is_3d());
+  mol.confs().emplace_back(3, 0);
+  ASSERT_TRUE(mol.is_3d());
+
+  pdb.clear();
+  EXPECT_GE(write_pdb(pdb, mol), 0);
+  EXPECT_TRUE(pdb.empty()) << pdb;
+
+  pdb.clear();
+  EXPECT_GE(write_pdb(pdb, mol, 1), 0);
+  NURI_EXPECT_STRTRIM_EQ(pdb, "MODEL        1\nENDMDL\n");
+}
+
 TEST(PDBWriteTest, MixedSubstructs) {
   Molecule mol;
   {

--- a/test/fmt/pdb_test.cpp
+++ b/test/fmt/pdb_test.cpp
@@ -525,6 +525,73 @@ TEST(PDBEmptyTest, EmptyModelBlock) {
   EXPECT_EQ(model->major_conf().cols(), 0);
 }
 
+TEST(PDBEmptyTest, EmptyFirstModelInStream) {
+  std::istringstream iss(
+      R"pdb(HEADER    TEST CLASSIFICATION                     01-JAN-25   ONLY
+MODEL        1
+ENDMDL
+MODEL        2
+ATOM      1  N   ALA A   1      11.104   6.134  -6.504  1.00  0.00           N
+ENDMDL
+END
+)pdb");
+  PDBReader reader(iss);
+  auto ms = reader.stream();
+
+  ASSERT_TRUE(ms.advance());
+  ASSERT_TRUE(ms.ok()) << ms.error_msg();
+  EXPECT_TRUE(ms.current().empty());
+  EXPECT_EQ(internal::get_key(ms.current().props(), "model"), "1");
+
+  ASSERT_TRUE(ms.advance());
+  ASSERT_TRUE(ms.ok()) << ms.error_msg();
+  EXPECT_EQ(ms.current().num_atoms(), 1);
+  EXPECT_EQ(internal::get_key(ms.current().props(), "model"), "2");
+
+  EXPECT_FALSE(ms.advance());
+}
+
+TEST(PDBEmptyTest, AllModelsEmptyInStream) {
+  std::istringstream iss(
+      R"pdb(HEADER    TEST CLASSIFICATION                     01-JAN-25   ONLY
+MODEL        1
+ENDMDL
+MODEL        2
+ENDMDL
+END
+)pdb");
+  PDBReader reader(iss);
+  auto ms = reader.stream();
+
+  for (std::string_view model: { "1", "2" }) {
+    ASSERT_TRUE(ms.advance());
+    ASSERT_TRUE(ms.ok()) << ms.error_msg();
+    EXPECT_TRUE(ms.current().empty());
+    EXPECT_EQ(internal::get_key(ms.current().props(), "model"), model);
+  }
+
+  EXPECT_FALSE(ms.advance());
+}
+
+TEST(PDBEmptyTest, TrailingRecordsAfterLastModel) {
+  std::istringstream iss(
+      R"pdb(HEADER    TEST CLASSIFICATION                     01-JAN-25   ONLY
+MODEL        1
+ATOM      1  N   ALA A   1      11.104   6.134  -6.504  1.00  0.00           N
+ENDMDL
+REMARK   2 RESOLUTION.
+END
+)pdb");
+  PDBReader reader(iss);
+  auto ms = reader.stream();
+
+  ASSERT_TRUE(ms.advance());
+  ASSERT_TRUE(ms.ok()) << ms.error_msg();
+  EXPECT_EQ(ms.current().num_atoms(), 1);
+
+  EXPECT_FALSE(ms.advance());
+}
+
 TEST(PDBEmptyTest, EmptyBlockIsError) {
   ParseResult<Molecule> mol = read_pdb({});
   ASSERT_FALSE(mol);

--- a/test/fmt/pdb_test.cpp
+++ b/test/fmt/pdb_test.cpp
@@ -282,8 +282,7 @@ ENDMDL
 
   int cnt = 0;
   while (ms.advance()) {
-    const Molecule &mol = ms.current();
-    EXPECT_TRUE(mol.empty());
+    EXPECT_FALSE(ms.ok()) << "Molecule index: " << cnt;
     ++cnt;
   }
   EXPECT_EQ(cnt, 4);

--- a/test/fmt/sdf_test.cpp
+++ b/test/fmt/sdf_test.cpp
@@ -641,17 +641,6 @@ $$$$
 test
 
 
- 15 16  0     1  0  0  0  0  0999 V2000
-M  V30 BEGIN CTAB
-M  V30 COUNTS 6 5 0 0 1
-M  V30 BEGIN ATOM
-M  V30 END ATOM
-M  V30 END CTAB
-M  END
-$$$$
-test
-
-
   1  0  0     1  0  0  0  0  0999 V2000
    74.7080   60.5120   32.8430 ZZ  0  0  0  0  0  0  0  0  0  0  0  0
 M END
@@ -704,8 +693,62 @@ M END
 $$$$
 )sdf");
 
-  for (int i = 0; i < 12; ++i)
+  for (int i = 0; i < 11; ++i)
     NURI_FMT_TEST_PARSE_FAIL();
+}
+
+TEST_F(SDFTest, ReportMalformedReason) {
+  set_test_string(R"sdf(test
+
+
+ 15 16  0     1  0  0  0  0  0999 V1000
+M  END
+$$$$
+)sdf");
+
+  NURI_FMT_TEST_PARSE_FAIL_MSG("unknown SDF version");
+}
+
+TEST_F(SDFTest, EmptyMolecule) {
+  set_test_string(R"sdf(v2000 empty
+
+
+  0  0  0     0  0  0  0  0  0999 V2000
+M  END
+$$$$
+v3000 empty
+
+
+  0  0  0     0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 0 0 0 0 0
+M  V30 BEGIN ATOM
+M  V30 END ATOM
+M  V30 END CTAB
+M  END
+$$$$
+declared but absent
+
+
+ 15 16  0     1  0  0  0  0  0999 V2000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 6 5 0 0 1
+M  V30 BEGIN ATOM
+M  V30 END ATOM
+M  V30 END CTAB
+M  END
+$$$$
+)sdf");
+
+  NURI_FMT_TEST_NEXT_EMPTY_MOL("v2000 empty");
+  ASSERT_EQ(mol().confs().size(), 1);
+  EXPECT_EQ(mol().confs()[0].cols(), 0);
+
+  NURI_FMT_TEST_NEXT_EMPTY_MOL("v3000 empty");
+  ASSERT_EQ(mol().confs().size(), 1);
+  EXPECT_EQ(mol().confs()[0].cols(), 0);
+
+  NURI_FMT_TEST_NEXT_EMPTY_MOL("declared but absent");
 }
 
 TEST_F(SDFTest, Write2D) {

--- a/test/fmt/smiles_test.cpp
+++ b/test/fmt/smiles_test.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include "fmt_test_common.h"
+#include "test_utils.h"
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/base.h"
 
@@ -995,7 +996,7 @@ TEST(SmilesFactoryTest, CreationTest) {
   std::vector<std::string> block = sr->next();
   ASSERT_FALSE(block.empty());
 
-  Molecule mol = sr->parse(block);
+  Molecule mol = internal::must_parse(sr->parse(block));
   EXPECT_FALSE(mol.empty());
 
   MoleculeSanitizer sanitizer(mol);

--- a/test/fmt/smiles_test.cpp
+++ b/test/fmt/smiles_test.cpp
@@ -18,6 +18,7 @@
 #include "test_utils.h"
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/base.h"
+#include "nuri/fmt/parse_result.h"
 
 namespace nuri {
 namespace {
@@ -983,6 +984,47 @@ TEST_F(SmilesTest, ManyRings) {
   EXPECT_EQ(mol().num_bonds(), 266);
   EXPECT_EQ(mol().num_fragments(), 1);
   EXPECT_EQ(mol().num_sssr(), 131);
+}
+
+TEST(SmilesEmptyTest, EmptyMolecule) {
+  ParseResult<Molecule> res = read_smiles({ "" });
+  ASSERT_FALSE(res);
+  EXPECT_THAT(res.error_msg(), testing::HasSubstr("invalid SMILES"));
+
+  res = read_smiles({ "\tname" });
+  ASSERT_FALSE(res);
+  EXPECT_THAT(res.error_msg(), testing::HasSubstr("invalid SMILES"));
+
+  res = read_smiles({ "  CCO" });
+  ASSERT_FALSE(res);
+  EXPECT_THAT(res.error_msg(), testing::HasSubstr("invalid SMILES"));
+
+  res = read_smiles({});
+  ASSERT_FALSE(res);
+  EXPECT_THAT(res.error_msg(), testing::HasSubstr("empty SMILES block"));
+
+  res = read_smiles({ "error" });
+  ASSERT_FALSE(res);
+  EXPECT_THAT(res.error_msg(), testing::HasSubstr("invalid SMILES"));
+}
+
+TEST_F(SmilesTest, IgnoreWhitespaceLeadingLines) {
+  set_test_string("  CCO\n\tname\n\nC methane\n");
+  NURI_FMT_TEST_NEXT_MOL("methane", 1, 0);
+}
+
+TEST(SmilesEmptyTest, WriteEmptyMolecule) {
+  Molecule mol;
+  mol.name() = "empty mol";
+
+  std::string smi;
+  ASSERT_TRUE(write_smiles(smi, mol));
+  EXPECT_EQ(smi, "\tempty mol\n");
+
+  std::istringstream iss(smi);
+  SmilesReader reader(iss);
+  auto ms = reader.stream();
+  EXPECT_FALSE(ms.advance());
 }
 
 TEST(SmilesFactoryTest, CreationTest) {

--- a/test/include/fmt_test_common.h
+++ b/test/include/fmt_test_common.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <string_view>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "nuri/core/molecule.h"
@@ -21,12 +22,35 @@
 #define NURI_FMT_TEST_PARSE_FAIL()                                             \
   do {                                                                         \
     ASSERT_TRUE(this->advance()) << "Molecule index: " << this->idx_;          \
+    EXPECT_FALSE(this->ok()) << "Molecule index: " << this->idx_;              \
+  } while (false)
+
+#define NURI_FMT_TEST_PARSE_FAIL_MSG(substr)                                   \
+  do {                                                                         \
+    ASSERT_TRUE(this->advance()) << "Molecule index: " << this->idx_;          \
+    ASSERT_FALSE(this->ok()) << "Molecule index: " << this->idx_;              \
+    EXPECT_THAT(this->error_msg(), ::testing::HasSubstr(substr))               \
+        << "Molecule index: " << this->idx_;                                   \
+  } while (false)
+
+#define NURI_FMT_TEST_NEXT_EMPTY_MOL(mol_name)                                 \
+  do {                                                                         \
+    ASSERT_TRUE(this->advance()) << "Molecule index: " << this->idx_;          \
+    ASSERT_TRUE(this->ok()) << this->error_msg();                              \
+                                                                               \
+    MoleculeSanitizer sanitizer(this->mol());                                  \
+    EXPECT_TRUE(sanitizer.sanitize_all()) << "Molecule index: " << this->idx_; \
+                                                                               \
+    EXPECT_EQ(this->mol().name(), mol_name)                                    \
+        << "Molecule index: " << this->idx_;                                   \
     EXPECT_TRUE(this->mol().empty()) << "Molecule index: " << this->idx_;      \
+    EXPECT_EQ(this->mol().num_bonds(), 0) << "Molecule index: " << this->idx_; \
   } while (false)
 
 #define NURI_FMT_TEST_ERROR_MOL()                                              \
   do {                                                                         \
     ASSERT_TRUE(this->advance()) << "Molecule index: " << this->idx_;          \
+    ASSERT_TRUE(this->ok()) << this->error_msg();                              \
     MoleculeSanitizer sanitizer(this->mol());                                  \
     EXPECT_FALSE(sanitizer.sanitize_all())                                     \
         << "Molecule index: " << this->idx_;                                   \
@@ -35,6 +59,7 @@
 #define NURI_FMT_TEST_NEXT_MOL(mol_name, natoms, nbonds)                       \
   do {                                                                         \
     ASSERT_TRUE(this->advance()) << "Molecule index: " << this->idx_;          \
+    ASSERT_TRUE(this->ok()) << this->error_msg();                              \
                                                                                \
     MoleculeSanitizer sanitizer(this->mol());                                  \
     EXPECT_TRUE(sanitizer.sanitize_all()) << "Molecule index: " << this->idx_; \
@@ -90,6 +115,10 @@ public:
     return ms_.advance();
   }
 
+  bool ok() const { return ms_.ok(); }
+
+  std::string_view error_msg() const { return ms_.error_msg(); }
+
   Molecule &mol() { return ms_.current(); }
 
 protected:
@@ -123,6 +152,10 @@ public:
     ++idx_;
     return ms_.advance();
   }
+
+  bool ok() const { return ms_.ok(); }
+
+  std::string_view error_msg() const { return ms_.error_msg(); }
 
   Molecule &mol() { return ms_.current(); }
 

--- a/test/include/test_utils.h
+++ b/test/include/test_utils.h
@@ -15,6 +15,7 @@
 
 #include "nuri/core/molecule.h"
 #include "nuri/fmt/base.h"
+#include "nuri/fmt/parse_result.h"
 
 #define NURI_EXPECT_EIGEN_EQ(a, b)                                             \
   EXPECT_PRED2(                                                                \
@@ -84,10 +85,19 @@ inline bool expect_line_eq_trim(std::string_view lhs, std::string_view rhs) {
   return lit == lhs_split.end() && rit == rhs_split.end();
 }
 
+template <class T>
+T must_parse(ParseResult<T> &&res) {
+  ABSL_CHECK(res)
+      << "Failed to parse: "
+      << (res.status() == ParseStatus::kEOF ? "end of input" : res.error_msg());
+  return *std::move(res);
+}
+
 inline Molecule read_first(std::string_view fmt, std::string_view data) {
   StringMoleculeReader<> reader(fmt, std::string { data });
   MoleculeStream<> stream = reader.stream();
   ABSL_CHECK(stream.advance());
+  ABSL_CHECK(stream.ok()) << stream.error_msg();
   return stream.current();
 }
 

--- a/test/tools/chimera_test.cpp
+++ b/test/tools/chimera_test.cpp
@@ -25,7 +25,7 @@ namespace fs = std::filesystem;
 Matrix3Xd read_first_calphas(const fs::path &path) {
   std::ifstream ifs(path);
   PDBReader reader(ifs);
-  PDBModel model = read_pdb_model(reader.next());
+  PDBModel model = internal::must_parse(read_pdb_model(reader.next()));
 
   std::vector<int> calphas;
   for (const PDBResidue &res: model.residues()) {

--- a/test/tools/galign/galign_test.cpp
+++ b/test/tools/galign/galign_test.cpp
@@ -21,9 +21,9 @@
 namespace nuri {
 namespace {
 TEST(GAlign, Rigid) {
-  Molecule templ = read_smiles({
+  Molecule templ = internal::must_parse(read_smiles({
       "O=C(C1CCC(CC(C)OC)CC1)c2cc3c(CC)ccc(C(C)C)c3cc2.Cl.[H][H]",
-  });
+  }));
 
   Matrix3Xd &tconf = templ.confs().emplace_back(3, templ.num_atoms());
   tconf.transpose() << -2.2395, -1.8709, 7.9552,  //
@@ -82,9 +82,9 @@ TEST(GAlign, Rigid) {
 }
 
 TEST(GAlign, Flexible) {
-  Molecule templ = read_smiles({
+  Molecule templ = internal::must_parse(read_smiles({
       "O=C(C1CCC(CC(C)OC)CC1)c2cc3c(CC)ccc(C(C)C)c3cc2.Cl.[H][H]",
-  });
+  }));
 
   Matrix3Xd &tconf = templ.confs().emplace_back(3, templ.num_atoms());
   tconf.transpose() << -2.2395, -1.8709, 7.9552,  //
@@ -156,7 +156,7 @@ TEST(GAlign, Flexible) {
 
 TEST(GAlign, FlexibleMaxConfClampedToPool) {
   // Needs a rotatable bond; otherwise the flexible path never builds a pool
-  Molecule mol = read_smiles({ "CCCC" });
+  Molecule mol = internal::must_parse(read_smiles({ "CCCC" }));
 
   Matrix3Xd &conf = mol.confs().emplace_back(3, mol.num_atoms());
   conf.transpose() << 0.0, 0.0, 0.0,  //
@@ -181,7 +181,7 @@ TEST(GAlign, FlexibleMaxConfClampedToPool) {
 }
 
 TEST(GAlign, FlexiblePrunesExcessRigidSeeds) {
-  Molecule mol = read_smiles({ "CCCCCC" });
+  Molecule mol = internal::must_parse(read_smiles({ "CCCCCC" }));
 
   Matrix3Xd &conf = mol.confs().emplace_back(3, mol.num_atoms());
   conf.transpose() << 0.00, 0.0, 0.0,  //
@@ -217,7 +217,7 @@ TEST(GAlign, FlexiblePrunesExcessRigidSeeds) {
 }
 
 TEST(GAlign, CoincidentRotatableBond) {
-  Molecule mol = read_smiles({ "CCCC" });
+  Molecule mol = internal::must_parse(read_smiles({ "CCCC" }));
 
   Matrix3Xd &conf = mol.confs().emplace_back(3, mol.num_atoms());
   conf.transpose() << 0.0, 0.0, 0.0,  //

--- a/test/tools/galign/prep_test.cpp
+++ b/test/tools/galign/prep_test.cpp
@@ -36,9 +36,9 @@ verify_rotation_info(const internal::GARotationInfo &ri, int ref,
 }
 
 TEST(GAlign, RotationInfo) {
-  Molecule mol = read_smiles({
+  Molecule mol = internal::must_parse(read_smiles({
       "O=C(C1CCC(CC(C)OC)CC1)c2cc3c(CC)ccc(C(C)C)c3cc2.Cl.[H][H]",
-  });
+  }));
 
   Matrix3Xd &conf = mol.confs().emplace_back(3, mol.num_atoms());
   conf.transpose() << -2.2395, -1.8709, 7.9552,  //


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/nurikit/pulls) for the same issue?
- [ ] Have you [linked the issue(s)](#linked-issues) you are working on?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `./scripts/run_clang_tools.sh` pass without any warnings?
- [ ] Have you built the project locally without any warnings and errors?
- [ ] Do all tests (if new tests are added, including the new ones) pass?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here:

- Closes #...

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking API change across the fmt reader surface and changes how callers distinguish EOF, parse errors, and empty molecules; risk is moderated by broad test coverage and clearer error reporting.
> 
> **Overview**
> Format parsing now returns **`ParseResult<T>`** (value, EOF, or error message) instead of using an empty `Molecule` to mean failure. **`MoleculeReader::parse`**, **`MoleculeStream`**, CIF **`CifParser::next`**, and the **`read_*`** helpers for SMILES, SDF, Mol2, PDB, and mmCIF are updated accordingly; streams expose **`ok()`** and **`error_msg()`**, and **`operator>>`** only moves a molecule when parsing succeeded.
> 
> **Empty (zero-atom) molecules** are valid results for PDB (header-only / empty models), SDF, Mol2, and mmCIF blocks without atom sites; SMILES still rejects whitespace-only lines and does not represent atom-less structures in a SMILES file. PDB splitting and coordinate-section errors now return explicit error strings instead of silent empty mols.
> 
> CIF **`internal::CifBlock`** drops EOF/error sentinel block types; stream state lives on **`ParseResult`**. Python/C++ callers and fuzz targets are adjusted to check **`ParseResult`** and propagate **`error_msg()`** in exceptions and logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2a940095768d9f3ec7ba360601bce2d0e4489f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->